### PR TITLE
fix: avoid eicweb trigger on workflow_dispatch

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -29,7 +29,7 @@ jobs:
         username: ${{ secrets.GITLAB_USERNAME }}
         ciskip: true
     - name: Trigger EICweb
-      if: ${{ github.event_name != 'delete' }}
+      if: ${{ github.event_name != 'delete' && github.event_name != 'workflow_dispatch' }}
       uses: eic/trigger-gitlab-ci@v3
       with:
         url: https://eicweb.phy.anl.gov


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR should avoid the duplicate eicweb pipelines when changes are pushed to eicweb and mirrored to github.
