### PR TITLE
fix: ensure spack env exists before activation

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -52,6 +52,7 @@ ENV GIT_TERMINAL_PROMPT=0
 # Concretization (default environment)
 RUN <<EOF
 set -e
+spack env create ${ENV}
 spack env activate --without-view --dir ${SPACK_ENV}
 spack concretize --force
 spack --color=never find --long --no-groups --show-concretized --format "{name}" \


### PR DESCRIPTION
Related to #23 