### PR TITLE
fix: don't run reconstruction_benchmarks for eicrecon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -696,7 +696,7 @@ benchmarks:physics:nightly:
 benchmarks:reconstruction:default:
   extends: .benchmarks:default
   rules:
-   - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION != ""'
+   - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
   variables:
     BENCHMARKS_CONTAINER: eic_ci
     BENCHMARKS_TAG: "${INTERNAL_TAG}-default"
@@ -707,7 +707,7 @@ benchmarks:reconstruction:default:
 benchmarks:reconstruction:nightly:
   extends: .benchmarks:nightly
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION != ""'
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
     - !reference ['.nightly', rules]
   variables:
     BENCHMARKS_CONTAINER: eic_ci


### PR DESCRIPTION
Looks like the condition is inverted. Also, it appears, reconstruction benchmarks still run for both epic and EICrecon. Let's fix this anyway.