### PR TITLE
fix: remove when_possible from eic_xl and eic_cuda

### DIFF
--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -4,8 +4,6 @@ spack:
   - ../packages.yaml
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
-  concretizer:
-    unify: when_possible # multiple epic versions
   specs:
   - acts +cuda
   - actsvg

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -4,8 +4,6 @@ spack:
   - ../packages.yaml
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
-  concretizer:
-    unify: when_possible # multiple epic versions
   specs:
   - acts
   - actsvg


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the 'concretizer: unify: when_possible' configuration from spack.yaml for xl and cuda.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: unneeded)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
