### PR TITLE
Make `cuda:torch` job manual for external triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -524,6 +524,11 @@ user_spack_environment:
   stage: benchmarks
   tags:
     - gpu
+  rules:
+    # Only eic_ci container is built for external trigger
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+      when: manual
+    - when: always
   needs: 
     - job: version
     - job: eic


### PR DESCRIPTION
We get pipelines stuck in "blocked" state because this job is not running making the stage uncompletable.