### PR TITLE
Update cache references to GITHUB_REF_POINT_SLUG in build-push workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -179,9 +179,9 @@ jobs:
             EICSPACK_VERSION=${{ steps.eic-spack.outputs.version }}
             jobs=${{ env.JOBS }}
           cache-from: |
-            type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_HEAD_REF_SLUG }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_REF_POINT_SLUG }}-${{ matrix.arch }}
             type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_BASE_REF_SLUG }}-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_HEAD_REF_SLUG }}-${{ matrix.arch }},mode=max
+          cache-to: type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_REF_POINT_SLUG }}-${{ matrix.arch }},mode=max
       - name: Export digest to file
         # The build-push action outputs the digest at steps.build.outputs.digest
         # We write this to a file for the next job
@@ -409,9 +409,9 @@ jobs:
             INTERNAL_TAG=${{ env.INTERNAL_TAG }}
             ENV=${{ matrix.ENV }}
           cache-from: |
-            type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}${{ matrix.ENV }}-${{ matrix.BUILD_TYPE }}-${{ env.GITHUB_HEAD_REF_SLUG }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}${{ matrix.ENV }}-${{ matrix.BUILD_TYPE }}-${{ env.GITHUB_REF_POINT_SLUG }}-${{ matrix.arch }}
             type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}${{ matrix.ENV }}-${{ matrix.BUILD_TYPE }}-${{ env.GITHUB_BASE_REF_SLUG }}-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}${{ matrix.ENV }}-${{ matrix.BUILD_TYPE }}-${{ env.GITHUB_HEAD_REF_SLUG }}-${{ matrix.arch }},mode=max
+          cache-to: type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}${{ matrix.ENV }}-${{ matrix.BUILD_TYPE }}-${{ env.GITHUB_REF_POINT_SLUG }}-${{ matrix.arch }},mode=max
       - name: Export digest to file
         # The build-push action outputs the digest at steps.build.outputs.digest
         # We write this to a file for the next job


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Cache to GITHUB_HEAD_REF_SLUG fails since undefined in master branch. Use GITHUB_REF_POINT_SLUG which is master in master branch and branch name in pull request. Simple GITHUB_REF_NAME is 34/merge for a pull request and not appropriate. This should improve caching since we don't push caches to debian_stable_base--amd64 with a missing master.

Run on master: https://github.com/eic/containers/actions/runs/19477388296/job/55740568431#step:3:1073

Run on branch: https://github.com/eic/containers/actions/runs/19484556416/job/55763778152#step:3:1074

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no cache)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
