### PR TITLE
Remove '%clang' requirement from several ACTS users

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -18,7 +18,6 @@ packages:
     - any_of: [build_type=Release, '@:']
   acts:
     require:
-    - '%clang'
     - '@39.2.0'
     - cxxstd=20 +dd4hep ~edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +tgeo +pr4496 +pr4502 +pr4620
   actsvg:
@@ -125,7 +124,6 @@ packages:
     - '@1.1.14'
   eicrecon:
     require:
-    - '%clang'
     - '@1.30.1' # EICRECON_VERSION
   eigen:
     require:
@@ -229,7 +227,6 @@ packages:
     - -ipo +podio +root +zmq
   juggler:
     require:
-    - '%clang'
     - '@15.0.2' # JUGGLER_VERSION
     - cxxstd=20
   julia:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes the '%clang' requirement from multiple packages in the YAML configuration. The requirement was added some while back when the version of gcc was too old to compile ACTS (and other programs that include ACTS).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: technical debt)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
