### PR TITLE
feat: `geant4 +vecgeom ^vecgeom +cuda` when building cuda

### DIFF
--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -36,7 +36,7 @@ spack:
   - g4adept +cuda
   - gaudi
   - gdb
-  - geant4
+  - geant4 +vecgeom
   - graphviz
   - hepmc3
   - heppdt

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -101,5 +101,6 @@ spack:
   - spdlog
   - stow
   - valgrind
+  - vecgeom +cuda cuda_arch=75
   - xrootd
   - xeyes

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -98,6 +98,6 @@ spack:
   - spdlog
   - stow
   - valgrind
-  - vecgeom +cuda cuda_arch=75
+  - vecgeom +cuda
   - xrootd
   - xeyes

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -4,8 +4,6 @@ spack:
   - ../packages.yaml
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
-  concretizer:
-    unify: when_possible # multiple epic versions
   specs:
   - acts +cuda
   - actsvg

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -22,7 +22,6 @@ spack:
   - dawncut
   - dd4hep
   - dpmjet
-  - east
   - edm4hep
   - eic-opticks
   - eic-smear

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -211,7 +211,7 @@ packages:
     - '@11.3.2.east'
     - cxxstd=20 +threads -vtk
     - one_of: [+opengl +qt +x11, -opengl -qt -x11]
-    - one_of: [-vecgeom, +vecgeom ^vecgeom +cuda]
+    - one_of: [-vecgeom, +vecgeom]
   gettext: 
     require:
     - +libxml2

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -212,7 +212,7 @@ packages:
     - cxxstd=20 +threads -vtk
     - one_of: [+opengl +qt +x11, -opengl -qt -x11]
     - one_of: [-vecgeom, +vecgeom]
-  gettext: 
+  gettext:
     require:
     - +libxml2
   gfal2:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -209,9 +209,10 @@ packages:
   geant4:
     require:
     - '@11.3.2.east'
-    - cxxstd=20 -vecgeom +threads -timemory -vtk
+    - cxxstd=20 +threads -vtk
     - any_of: [+opengl +qt +x11, -opengl -qt -x11]
-  gettext:
+    - any_of: [-vecgeom, +vecgeom ^vecgeom +cuda]
+  gettext: 
     require:
     - +libxml2
   gfal2:
@@ -618,6 +619,7 @@ packages:
   vecgeom:
     require:
     - '@2'
+    - cxxstd=20 +gdml +geant4 +root
   xerces-c:
     require:
     - cxxstd=20

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -210,8 +210,8 @@ packages:
     require:
     - '@11.3.2.east'
     - cxxstd=20 +threads -vtk
-    - any_of: [+opengl +qt +x11, -opengl -qt -x11]
-    - any_of: [-vecgeom, +vecgeom ^vecgeom +cuda]
+    - one_of: [+opengl +qt +x11, -opengl -qt -x11]
+    - one_of: [-vecgeom, +vecgeom ^vecgeom +cuda]
   gettext: 
     require:
     - +libxml2
@@ -325,7 +325,7 @@ packages:
     require:
     - '@1.4.6'
     - +http
-    - any_of: [+geocad, -geocad]
+    - one_of: [+geocad, -geocad]
   ollama:
     require:
     - '@0.13.1:'
@@ -565,7 +565,7 @@ packages:
     require:
     - '@6.38.00'
     - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
-    - any_of: [+opengl +webgui, -opengl -webgui]
+    - one_of: [+opengl +webgui, -opengl -webgui]
   sherpa:
     require:
     - '@3.0.1'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -619,7 +619,7 @@ packages:
   vecgeom:
     require:
     - '@2'
-    - cxxstd=20 +gdml +geant4 +root
+    - cxxstd=20 +gdml ~geant4 +root
   xerces-c:
     require:
     - cxxstd=20


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR aims to ensure that we use geant4 and vecgeom with cuda support throughout the cuda images.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: geant4 does not use vecgeom with cuda in the cuda image)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
