### PR TITLE
feat: add CI job for default container build without any args

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -537,11 +537,11 @@ eic:noargs:
     - nocache=""
     - while !
       docker buildx build ${BUILD_OPTIONS} ${nocache}
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}${ENV}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
-                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64,mode=max
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:eic-noargs-${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:eic-noargs--${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:eic-noargs--${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:eic-noargs--${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:eic-noargs--${CI_COMMIT_REF_SLUG}-amd64,mode=max
                    --file containers/eic/Dockerfile
                    containers/eic
                    2>&1 | tee build.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,6 +343,36 @@ base:
         let attempts=$attempts+1 ;
       done
 
+base:no-args:
+  extends: .build
+  stage: base
+  needs:
+    - version
+  script:
+    - attempts=0
+    - nocache=""
+    - while !
+      docker buildx build --push ${BUILD_OPTIONS} ${nocache}
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64,mode=max
+                   --file containers/debian/Dockerfile
+                   containers/debian
+                   2>&1 | tee build.log
+      ; do
+        if grep "unknown blob" build.log ; then
+          nocache="--no-cache" ;
+        else
+          exit 1 ;
+        fi ;
+        if test ${attempts} -ge 1 ; then
+          echo "Failed to build on second attempt!" ;
+          exit 1 ;
+        fi ;
+        let attempts=$attempts+1 ;
+      done
 
 eic:
   parallel:
@@ -481,6 +511,38 @@ eic:
                    --secret type=env,id=GITHUB_REGISTRY_USER,env=GITHUB_REGISTRY_USER
                    --secret type=env,id=GITHUB_REGISTRY_TOKEN,env=GITHUB_REGISTRY_TOKEN
                    --provenance false
+                   containers/eic
+                   2>&1 | tee build.log
+      ; do
+        if grep "unknown blob" build.log ; then
+          nocache="--no-cache" ;
+        else
+          exit 1 ;
+        fi ;
+        if test ${attempts} -ge 1 ; then
+          echo "Failed to build on second attempt!" ;
+          exit 1 ;
+        fi ;
+        let attempts=$attempts+1 ;
+      done
+
+eic:noargs:
+  extends: .build
+  stage: eic
+  needs:
+    - version
+    - base
+  script:
+    - attempts=0
+    - nocache=""
+    - while !
+      docker buildx build ${BUILD_OPTIONS} ${nocache}
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}${ENV}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
+                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}${ENV}-${CI_COMMIT_REF_SLUG}-noargs-amd64,mode=max
+                   --file containers/eic/Dockerfile
                    containers/eic
                    2>&1 | tee build.log
       ; do

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,11 +353,11 @@ base:no-args:
     - nocache=""
     - while !
       docker buildx build --push ${BUILD_OPTIONS} ${nocache}
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-amd64
-                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-amd64,mode=max
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
+                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64,mode=max
                    --file containers/debian/Dockerfile
                    containers/debian
                    2>&1 | tee build.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -352,7 +352,7 @@ base:no-args:
     - attempts=0
     - nocache=""
     - while !
-      docker buildx build --push ${BUILD_OPTIONS} ${nocache}
+      docker buildx build ${BUILD_OPTIONS} ${nocache}
                    --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
                    --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
                    --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -542,6 +542,7 @@ eic:noargs:
                    --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:eic-noargs--${CI_DEFAULT_BRANCH_SLUG}-amd64
                    --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:eic-noargs--${CI_DEFAULT_BRANCH_SLUG}-amd64
                    --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:eic-noargs--${CI_COMMIT_REF_SLUG}-amd64,mode=max
+                   --build-context spack-environment=spack-environment
                    --file containers/eic/Dockerfile
                    containers/eic
                    2>&1 | tee build.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,7 +343,7 @@ base:
         let attempts=$attempts+1 ;
       done
 
-base:no-args:
+base:noargs:
   extends: .build
   stage: base
   needs:
@@ -353,11 +353,11 @@ base:no-args:
     - nocache=""
     - while !
       docker buildx build ${BUILD_OPTIONS} ${nocache}
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
-                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:${BUILD_IMAGE}-${CI_DEFAULT_BRANCH_SLUG}-noargs-amd64
-                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:${BUILD_IMAGE}-${CI_COMMIT_REF_SLUG}-noargs-amd64,mode=max
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:base-noargs-${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:base-noargs-${CI_COMMIT_REF_SLUG}-amd64
+                   --cache-from type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:base-noargs-${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-from type=registry,ref=${GH_REGISTRY}/${GH_REGISTRY_USER}/buildcache:base-noargs-${CI_DEFAULT_BRANCH_SLUG}-amd64
+                   --cache-to type=registry,ref=${CI_REGISTRY}/${CI_PROJECT_PATH}/buildcache:base-noargs-${CI_COMMIT_REF_SLUG}-amd64,mode=max
                    --file containers/debian/Dockerfile
                    containers/debian
                    2>&1 | tee build.log

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -237,6 +237,7 @@ target=${target[${TARGETPLATFORM}]}
 spack config --scope site add "packages:all:require:[target=${target}]"
 spack config --scope site add "packages:all:target:[${target}]"
 spack config blame packages
+mkdir -p $HOME/.spack/
 spack config --scope user add "config:suppress_gpg_warnings:true"
 spack config --scope user add "config:build_jobs:${jobs}"
 spack config --scope user add "config:db_lock_timeout:${jobs}00"

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -3,3 +3,13 @@ To build the container in this directory:
 ```
 docker buildx build -f Dockerfile .
 ```
+
+**Note:** The minimal build command shown above will assume default values for all build arguments. For this container, that means 'develop' versions for all spack repositories:
+- `SPACK_VERSION=develop`
+- `SPACKPACKAGES_VERSION=develop`
+- `KEY4HEPSPACK_VERSION=main`
+- `EICSPACK_VERSION=develop`
+
+**Important:** Docker layer caching will not automatically update the previous checkout of these 'develop' versions. To ensure you have the latest commits, you may need to use `--no-cache` or rebuild without cache.
+
+For specific operations as used in CI builds (including custom build arguments and cache management), please refer to the GitHub and GitLab CI workflows in this repository.

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -41,6 +41,8 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.title="Electron-Ion Collider build concretization image (default configuration, $TARGETPLATFORM)"
 
 ## Copy our default environment
+## Note that a named build context is *required* for this build:
+## e.g. --build-context spack-environment=../../spack-environment
 COPY --from=spack-environment . /opt/spack-environment/
 ARG ENV=xl
 ENV SPACK_ENV=/opt/spack-environment/${ENV}
@@ -114,6 +116,8 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.title="Electron-Ion Collider runtime concretization image (default configuration, $TARGETPLATFORM)"
 
 ## Copy our default environment
+## Note that a named build context is *required* for this build:
+## e.g. --build-context spack-environment=../../spack-environment
 COPY --from=spack-environment . /opt/spack-environment/
 ARG ENV=xl
 ENV SPACK_ENV=/opt/spack-environment/${ENV}

--- a/containers/eic/README.md
+++ b/containers/eic/README.md
@@ -3,3 +3,16 @@ To build the container in this directory:
 ```
 docker buildx build -f Dockerfile --build-context spack-environment=../../spack-environment .
 ```
+
+**Note:** The minimal build command shown above will assume default values for all build arguments. For this container, that means 'develop' versions for all spack repositories:
+- `BUILDER_IMAGE=debian_stable_base`
+- `RUNTIME_IMAGE=debian_stable_base`
+- `ENV=xl`
+- `BENCHMARK_COM_VERSION=master`
+- `BENCHMARK_DET_VERSION=master`
+- `BENCHMARK_REC_VERSION=master`
+- `BENCHMARK_PHY_VERSION=master`
+
+**Important:** Docker layer caching will not automatically update the previous checkout of these 'master' versions. To ensure you have the latest commits, you may need to use `--no-cache` or rebuild without cache.
+
+For specific operations as used in CI builds (including custom build arguments and cache management), please refer to the GitHub and GitLab CI workflows in this repository.


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds a default build job for the base and eic containers to verify that our simple instructions without extensive build-args are actually functional.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: basic build not tested, impacting users who wish to build the containers themselves)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
