### PR TITLE
.gitlab-ci.yml: mark some conditionally `when: manual` jobs as `never`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -399,7 +399,7 @@ eic:
         PLATFORM: linux/amd64
   rules:
     - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger"'
-      when: manual
+      when: never
     - when: always
   extends: .build
   stage: eic
@@ -528,7 +528,7 @@ user_spack_environment:
   rules:
     # Only eic_ci container is built for external trigger
     - if: '$CI_PIPELINE_SOURCE == "trigger"'
-      when: manual
+      when: never
     - when: always
   needs: 
     - job: version


### PR DESCRIPTION
`when: manual` leads to full pipelines being in "blocked" status. Apparently, we'd need to enable `allow_failure` to unblock those. This is an alternative approach.