### PR TITLE
Remove concurrency settings from mirror.yaml

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -6,10 +6,6 @@ on:
   push:
   workflow_dispatch:
 
-concurrency:
-  group: mirror
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Mirror and Trigger EICweb


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes concurrency settings from the mirror workflow. We don't want either new or old workflows to get canceled. Until further investigation, we want them all to be executed, in the order they are committed.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: missing commits due to race conditions)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
