### PR TITLE
fix: build all containers on eicweb when triggered from eic/containers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,7 +398,7 @@ eic:
         RUNTIME_IMAGE: cuda_devel
         PLATFORM: linux/amd64
   rules:
-    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger"' && $GITHUB_REPOSITORY != "eic/containers"'
+    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
       when: never
     - when: always
   extends: .build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,7 +398,7 @@ eic:
         RUNTIME_IMAGE: cuda_devel
         PLATFORM: linux/amd64
   rules:
-    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger"'
+    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger"' && $GITHUB_REPOSITORY != "eic/containers"'
       when: never
     - when: always
   extends: .build


### PR DESCRIPTION
### Briefly, what does this PR introduce?
When we are making changes to the containers here (on eic/containers), we do want the trigger to do more than just building eic_ci.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: changes to containers other than eic_ci are not tested)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
