### PR TITLE
fix: actually install irt2

### DIFF
--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -25,6 +25,7 @@ spack:
   - heppdt
   - imagemagick
   - irt
+  - irt2
   - iwyu
   - jana2
   - nopayloadclient

--- a/spack-environment/ci_without_acts/spack.yaml
+++ b/spack-environment/ci_without_acts/spack.yaml
@@ -24,6 +24,7 @@ spack:
   - heppdt
   - imagemagick
   - irt
+  - irt2
   - iwyu
   - jana2
   - nopayloadclient

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -38,6 +38,7 @@ spack:
   - heppdt
   - imagemagick
   - irt
+  - irt2
   - jana2
   - k4actstracking
   - k4fwcore

--- a/spack-environment/prod/spack.yaml
+++ b/spack-environment/prod/spack.yaml
@@ -11,6 +11,7 @@ spack:
   - geant4 -opengl
   - hepmc3
   - irt
+  - irt2
   - jana2
   - npsim -geocad
   - root -opengl -webgui

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -45,6 +45,7 @@ spack:
   - heppdt
   - imagemagick
   - irt
+  - irt2
   - iwyu
   - jana2
   - k4actstracking


### PR DESCRIPTION
These entries are actually needed to have the package present in the container.