### PR TITLE
feat: disable nightly builds on release branches/tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,6 +398,14 @@ eic:
         RUNTIME_IMAGE: cuda_devel
         PLATFORM: linux/amd64
   rules:
+    # Don't build nightly in the following cases
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
+      when: never
+    # Skip containers other than eic_ci for epic or EICrecon trigger
     - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
       when: never
     - when: always
@@ -595,6 +603,15 @@ eic_xl:singularity:nightly:
   variables:
     BUILD_TYPE: nightly
     BUILD_IMAGE: eic_xl
+  rules:
+    # Don't build nightly in the following cases
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
+      when: never
+    - when: always
   needs:
     - job: version
     - job: eic
@@ -640,6 +657,15 @@ eic_xl:singularity:nightly:
 
 .benchmarks:nightly:
   extends: .benchmarks
+  rules:
+    # Don't build nightly in the following cases
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
+      when: never
+    - when: always
   needs: 
     - job: version
     - job: eic
@@ -679,8 +705,8 @@ benchmarks:detector:default:
 benchmarks:detector:nightly:
   extends: .benchmarks:nightly
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - !reference ['.nightly', rules]
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
   variables:
     BENCHMARKS_CONTAINER: eic_ci
     BENCHMARKS_TAG: "${INTERNAL_TAG}-nightly"
@@ -702,8 +728,8 @@ benchmarks:phyiscs:default:
 benchmarks:physics:nightly:
   extends: .benchmarks:nightly
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
     - !reference ['.nightly', rules]
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'
   variables:
     BENCHMARKS_CONTAINER: eic_ci
     BENCHMARKS_TAG: "${INTERNAL_TAG}-nightly"


### PR DESCRIPTION
It doesn't make sense to build nightly container for tags, and it may cause us to pickup irrelevant regressions. This just disables those container builds and related benchmarks.