### PR TITLE
fix: Update spack ghcr mirror to SPACKPACKAGES_VERSION

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -254,7 +254,7 @@ EOF
 RUN --mount=type=cache,target=/var/cache/spack <<EOF
 set -e
 spack mirror add --scope site --signed spack-${SPACK_VERSION} https://binaries.spack.io/${SPACK_VERSION}
-spack mirror add --scope site --unsigned ghcr-${SPACK_VERSION} oci://ghcr.io/eic/spack-${SPACK_VERSION}
+spack mirror add --scope site --unsigned ghcr-${SPACKPACKAGES_VERSION} oci://ghcr.io/eic/spack-${SPACKPACKAGES_VERSION}
 spack mirror list
 EOF
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updates the default read-only ghcr mirror to use SPACKPACKAGES_VERSION as well. This doesn't affect CI (where a read-write mirror is provided as a secret in the run commands that actually install and write).

### What kind of change does this PR introduce?
- [x] Bug fix (issue: no buildcache mirror on end user builds)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
