### PR TITLE
fix: on tag, look for release of epic@YY.MM.X in $ENV/epic/spack.yaml instead of $ENV/spack.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,7 @@ version:
         VERSION="${CI_COMMIT_TAG:1}"
         EXPORT_TAG="${VERSION}"
         GEOM_VERSION="$(echo "$VERSION" | sed -e 's/-.\+$//')" # cut out suffixes like -stable
-        for ENV_FILE in spack-environment/xl/spack.yaml spack-environment/cuda/spack.yaml; do
+        for ENV_FILE in spack-environment/xl/epic/spack.yaml spack-environment/cuda/epic/spack.yaml; do
           grep -- "- epic@${GEOM_VERSION}" "${ENV_FILE}" >/dev/null \
             || ( echo "Unable to locate epic release package for ${GEOM_VERSION} in ${ENV_FILE}"; exit 1; )
         done


### PR DESCRIPTION
In https://github.com/eic/containers/commit/db80abd4006130f5ee64480ac7605860ed0d006b part of the `$ENV/spack.yaml` file was split int `$ENV/spack.yaml`. We have a check in the version job that runs only for tagged releases and checks whether epic of corresponding tag is present. That check should look in the new file now, or we may not be able to tag the next release.