### PR TITLE
fix: rework .nightly skip rules, rely on BUILD_TYPE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,11 +249,18 @@ status:pending:
 ## rules for nightly jobs
 .nightly:
   rules:
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-      when: on_success
-    - when: never
+    # Don't build nightly in the following cases
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
+      when: never
+    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
+      when: never
+    # Skip containers other than eic_ci for epic or EICrecon trigger
+    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
+      when: never
+    # Caller needs to provide their own whitelist
+    #- when: always
 
 ## Images:
 ## debian_testing_base --> eic_dev  --> eic_xl
@@ -382,16 +389,7 @@ eic:
         RUNTIME_IMAGE: cuda_devel
         PLATFORM: linux/amd64
   rules:
-    # Don't build nightly in the following cases
-    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
-      when: never
-    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
-      when: never
-    - if: '$BUILD_TYPE == "nightly" && $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
-      when: never
-    # Skip containers other than eic_ci for epic or EICrecon trigger
-    - if: '$ENV != "ci" && $CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
-      when: never
+    - !reference ['.nightly', rules]
     - when: always
   extends: .build
   stage: eic
@@ -601,6 +599,9 @@ eic_xl:singularity:nightly:
 
 .benchmarks:default:
   extends: .benchmarks
+  variables:
+    - BUILD_TYPE: default
+    - !reference ['.benchmarks', variables]
   needs: 
     - job: version
     - job: eic
@@ -617,15 +618,9 @@ eic_xl:singularity:nightly:
 
 .benchmarks:nightly:
   extends: .benchmarks
-  rules:
-    # Don't build nightly in the following cases
-    - if: '$CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-(alpha|beta|stable)/'          ## main stable branch: vX.Y-stable
-      when: never
-    - if: '$CI_COMMIT_BRANCH =~ /^v[0-9]+\.[0-9]+-[a-z]+-(alpha|beta|stable)/'   ## special stable branch: vX.Y-acadia-stable (etc)
-      when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/'                         ## commit tags start with vX.Y.Z with optional suffix
-      when: never
-    - when: always
+  variables:
+    - BUILD_TYPE: nightly
+    - !reference ['.benchmarks', variables]
   needs: 
     - job: version
     - job: eic
@@ -711,8 +706,8 @@ benchmarks:reconstruction:default:
 benchmarks:reconstruction:nightly:
   extends: .benchmarks:nightly
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
     - !reference ['.nightly', rules]
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
   variables:
     BENCHMARKS_CONTAINER: eic_ci
     BENCHMARKS_TAG: "${INTERNAL_TAG}-nightly"


### PR DESCRIPTION
I discover that `.nightly` took precedence in definitions of benchmark jobs and was already doing some things that I wanted, just not for the containers. This PR switches up the approach and introduces a common condition for not building nightly containers on tags and not running nightly benchmarks on tags/outside of main branch. We need to introduce BUILD_TYPE variable, but we can't matrix over it if we want to use `needs:parallel:matrix:` until we get
https://gitlab.com/gitlab-org/gitlab/-/issues/423553

This also does address a singularity job issue, without fixing which our development (epic/EICrecon) trigger pipelines don't work.