### PR TITLE
feat: skip user_spack_environment for downstream triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -484,6 +484,11 @@ eic:
 
 user_spack_environment:
   stage: benchmarks
+  rules:
+    # Skip for epic or EICrecon trigger
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
+      when: never
+    - when: always
   needs:
     - job: version
     - job: eic


### PR DESCRIPTION
This test is currently broken, we shouldn't require it for downstream users.