### PR TITLE
Remove llvm gold requirement from packages.yaml

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -251,9 +251,6 @@ packages:
     require:
     - '@6.5.5'
     - +python
-  llvm:
-    require:
-    - ~gold
   madx:
     require:
     - '@5.08.01:'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes `llvm ~gold` from the requirements since in spack v1.1.0 this leads to issues when we have an external `llvm` (without `gold` specification since not detected) and an internal `llvm ~gold`.

We have `llvm ~gold` since we run into issues with `numba` builds for `tensorflow` if we link with gold.

Ref: https://eicweb.phy.anl.gov/containers/eic_container/-/merge_requests/1158