### PR TITLE
Add `optix-dev` to the `cuda` environment

### DIFF
--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -50,6 +50,7 @@ spack:
   - npsim
   - onnx
   - opencascade
+  - optix-dev
   - osg-ca-certs
   - phonebook-cli
   - podio


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds `optix-dev` to the `cuda` environment.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: bring support for `opticks` closer to eic-shell)
- [ ] Documentation update
- [ ] Other: __
