### PR TITLE
fix: pull_request trigger for branches into master

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -2,7 +2,12 @@ name: Mirror and Trigger EICweb
 
 on:
   delete:
+  pull_request:
+    branches:
+    - master
   push:
+    branches:
+    - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR should avoid the empty mr tags being pushed from eicweb due to the trigger on push instead of pull_request.