### PR TITLE
feat: ollama-0.13.1

### DIFF
--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -30,6 +30,7 @@ spack:
   - jana2
   - nopayloadclient
   - npsim -geocad
+  - ollama
   - onnx
   - osg-ca-certs
   - podio

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -278,6 +278,9 @@ packages:
     - '@1.4.6'
     - +http
     - any_of: [+geocad, -geocad]
+  ollama:
+    require:
+    - '@0.13.1:'
   onnx:
     require:
     - '@1.17.0'

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -61,6 +61,7 @@ spack:
   - ninja
   - nopayloadclient
   - npsim
+  - ollama
   - onnx
   - opencascade
   - osg-ca-certs

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -63,6 +63,7 @@ a46e40be55d002e4708303735f7eb4aca2482d0a
 d6b78b9ed0cf6ac3d6ddfcbc287bc0db3cd645e7
 f201ecd5e5923b394d14f74bc220dea06b9ab28f
 2e05bbbe808442e761647da571500ee128654f4f
+9ec50db07733195bba922b8c6dcbbb1de9c56adf
 ---
 ## Optional hash table with comma-separated file list
 read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
@@ -129,3 +130,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## d6b78b9ed0cf6ac3d6ddfcbc287bc0db3cd645e7: acts: Add +gnn variant and add necessary dependencies
 ## f201ecd5e5923b394d14f74bc220dea06b9ab28f: acts: add v44.2.0
 ## 2e05bbbe808442e761647da571500ee128654f4f: acts: add v44.3.0
+## 9ec50db07733195bba922b8c6dcbbb1de9c56adf: ollama: add through v0.13.1


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds `ollama` to the ci and xl containers. It is intended to allow non-API-key requiring local-running LLM models, with (tentatively) LLMs pre-loaded to CVMFS, but otherwise also locally downloadable.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: AI)
- [ ] Documentation update
- [ ] Other: __