### PR TITLE
fix: eigen: require: @3.4.0

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -127,7 +127,7 @@ packages:
     - '@1.32.0' # EICRECON_VERSION
   eigen:
     require:
-    - '@3.4.1'
+    - '@3.4.0'
   emacs:
     require:
     - '@28.2:'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR downgrades `eigen` back to 3.4.0 since we see asan errors in some workflows.
