### PR TITLE
chore: cuda: update (gcc,clang) to (14,20)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -32,7 +32,7 @@ permissions:
 
 env:
   ## CUDA version and container operating system
-  CUDA_VERSION: 12.5.1
+  CUDA_VERSION: 12.8.2
   CUDA_OS: ubuntu24.04
 
   ## Default versions are specified in packages.yaml but can be overridden

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   SINGULARITY_IMAGE: quay.io/singularity/singularity:v3.11.5
 
   ## CUDA version and container operating system
-  CUDA_VERSION: 12.5.1
+  CUDA_VERSION: 12.8.2
   CUDA_OS: ubuntu24.04
 
   ## Default versions are specified in packages.yaml but can be overridden

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -104,7 +104,7 @@ case ${ID} in
     apt-get -yqq install software-properties-common
     add-apt-repository ppa:ubuntu-toolchain-r/ppa
     case ${VERSION_CODENAME} in
-      noble) GCC="-13" ; CLANG="-17" ;;
+      noble) GCC="-14" ; CLANG="-20" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   *) echo "Unsupported ID=${ID}" ; exit 1 ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -119,7 +119,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev flang${CLANG}
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -130,6 +130,7 @@ update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++${GCC} 100
 update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar${GCC} 100
 update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran${GCC} 100
 update-alternatives --install /usr/bin/clang clang /usr/bin/clang${CLANG} 100
+update-alternatives --install /usr/bin/flang flang /usr/bin/flang${CLANG} 100
 update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++${CLANG} 100
 update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format${CLANG} 100
 update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff${CLANG} 100

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -310,7 +310,7 @@ spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cud
 # Clang 20+ is not in CUDA's supported compiler list; amend the external spec so that
 # the +allow-unsupported-compilers variant disables the build-system conflict check.
 # Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
-yq -iy '.packages.cuda.externals[].spec += " +allow-unsupported-compilers"' ${SPACK_ROOT}/etc/spack/packages.yaml
+yq -iy 'if .packages.cuda.externals then .packages.cuda.externals[].spec += " +allow-unsupported-compilers" else . end' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame packages
 EOF
 

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -311,7 +311,7 @@ spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cud
 # Clang 20+ is not in CUDA's supported compiler list; amend the external spec so that
 # the +allow-unsupported-compilers variant disables the build-system conflict check.
 # Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
-yq -iy '.packages.cuda.externals[].spec += " +allow-unsupported-compilers"' ${SPACK_ROOT}/etc/spack/packages.yaml
+yq -iy 'if .packages.cuda.externals then .packages.cuda.externals[].spec += " +allow-unsupported-compilers" else . end' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame packages
 EOF
 

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -307,6 +307,10 @@ set -e
 spack external find --scope spack llvm
 spack external find --scope spack --not-buildable gcc
 spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cuda
+# Clang 20+ is not in CUDA's supported compiler list; amend the external spec so that
+# the +allow-unsupported-compilers variant disables the build-system conflict check.
+# Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
+yq -iy '.packages.cuda.externals[].spec += " +allow-unsupported-compilers"' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame packages
 EOF
 

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -122,7 +122,7 @@ apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
 apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
 if [ "${CLANG#-}" -ge 20 ]; then apt-get -yqq install flang${CLANG}; fi
 apt-get -yqq autoremove
-# Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
+# Remove symlinks loop observed in nvidia/cuda devel images
 rm -f /usr/bin/cpp /etc/alternatives/cpp
 # Ensure alternatives without version tags
 update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp${GCC} 100

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -308,6 +308,10 @@ set -e
 spack external find --scope spack llvm
 spack external find --scope spack --not-buildable gcc
 spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cuda
+# Clang 20+ is not in CUDA's supported compiler list; amend the external spec so that
+# the +allow-unsupported-compilers variant disables the build-system conflict check.
+# Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
+yq -iy '.packages.cuda.externals[].spec += " +allow-unsupported-compilers"' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame packages
 EOF
 

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -117,12 +117,6 @@ packages:
   cppcoro:
     require:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
-  cuda:
-    require:
-    # We disable CUDA's maximum supported compiler versions, e.g.:
-    #    conflicts("%clang@20:", when="+cuda ^cuda@:12.9")
-    # https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/build_systems/cuda.py
-    - +allow-unsupported-compilers
   curl:
     require:
     - tls=openssl

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -117,6 +117,12 @@ packages:
   cppcoro:
     require:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
+  cuda:
+    require:
+    # We disable CUDA's maximum supported compiler versions, e.g.:
+    #    conflicts("%clang@20:", when="+cuda ^cuda@:12.9")
+    # https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/build_systems/cuda.py
+    - +allow-unsupported-compilers
   curl:
     require:
     - tls=openssl

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -109,12 +109,6 @@ packages:
   cppcoro:
     require:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
-  cuda:
-    require:
-    # We disable CUDA's maximum supported compiler versions, e.g.:
-    #    conflicts("%clang@20:", when="+cuda ^cuda@:12.9")
-    # https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/build_systems/cuda.py
-    - +allow-unsupported-compilers
   dawn:
     require:
     - '@3_91a'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -109,6 +109,12 @@ packages:
   cppcoro:
     require:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
+  cuda:
+    require:
+    # We disable CUDA's maximum supported compiler versions, e.g.:
+    #    conflicts("%clang@20:", when="+cuda ^cuda@:12.9")
+    # https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/build_systems/cuda.py
+    - +allow-unsupported-compilers
   dawn:
     require:
     - '@3_91a'

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -23,6 +23,7 @@ a7c32f24cd5b69b237dc974804a71326306f4e58
 de97f131df3dbc940151f406afd5c2c1158a660c
 caf013be0ee1594fdbba8feb07ffecc88474a2b0
 75395349957ad785cca50002dffb18bbcb48af27
+acac89d6bb7079412e711a50a3f06681132a2723
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -43,3 +44,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## de97f131df3dbc940151f406afd5c2c1158a660c: TensorFlow: add v2.21.0
 ## caf013be0ee1594fdbba8feb07ffecc88474a2b0: Add missing xxd dep
 ## 75395349957ad785cca50002dffb18bbcb48af27: py-torch: ensure setuptools is not unnecessarily constrained for 2.10:
+## acac89d6bb7079412e711a50a3f06681132a2723: cuda: append --allow-unsupported-compiler to CUDAFLAGS for dependent_spec

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -28,7 +28,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
-11ad01e7b796d34571a2c9e0a72b483cc007cd3a
+acac89d6bb7079412e711a50a3f06681132a2723
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -54,4 +54,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
-## 11ad01e7b796d34571a2c9e0a72b483cc007cd3a: CudaPackage: append --allow-unsupported-compilers to CUDAFLAGS
+## acac89d6bb7079412e711a50a3f06681132a2723: cuda: append --allow-unsupported-compiler to CUDAFLAGS for dependent_spec

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -28,6 +28,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
+11ad01e7b796d34571a2c9e0a72b483cc007cd3a
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -53,3 +54,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
+## 11ad01e7b796d34571a2c9e0a72b483cc007cd3a: CudaPackage: append --allow-unsupported-compilers to CUDAFLAGS


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes some legacy base image distributions which are now unsupported, and upgraded gcc and clang to consistent versions. Clang is upgraded to 20 for new flang and to avoid tool chain mixing which has been leading to confusing behavior.

Needs:
- [x] #91 
- [x] #336 

### What kind of change does this PR introduce?
- [x] Bug fix (issue: remove unsupported base distributions)
- [x] New feature (issue: move towards flang)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes, newer clang on default images.