### PR TITLE
feat: add eic_tf concretization to github workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -407,6 +407,15 @@ jobs:
           runner: ubuntu-latest
           PLATFORM: linux/amd64
           target: builder_concretization_default
+        - BUILD_IMAGE: eic_
+          BUILD_TYPE: default
+          BUILDER_IMAGE: cuda_devel
+          RUNTIME_IMAGE: cuda_devel
+          ENV: tf
+          arch: amd64
+          runner: ubuntu-latest
+          PLATFORM: linux/amd64
+          target: builder_concretization_default
       fail-fast: false
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds the `eic_tf` concretization to the GitHub Actions workflow. This should catch concretization errors earlier, without having to wait for an eicweb build to fail.