### PR TITLE
feat(ci): add macOS CI workflow

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -32,48 +32,80 @@ jobs:
         with:
           submodules: recursive
       
+      - name: Extract Spack configuration
+        id: spack-config
+        run: |
+          # Source spack.sh to get SPACK_VERSION and SPACK_CHERRYPICKS
+          source spack.sh
+          echo "spack-version=${SPACK_VERSION}" >> $GITHUB_OUTPUT
+          echo "spack-cherrypicks<<EOF" >> $GITHUB_OUTPUT
+          echo "${SPACK_CHERRYPICKS}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Source spack-packages.sh to get SPACKPACKAGES_VERSION and SPACKPACKAGES_CHERRYPICKS
+          source spack-packages.sh
+          echo "spackpackages-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
+          echo "spackpackages-cherrypicks<<EOF" >> $GITHUB_OUTPUT
+          echo "${SPACKPACKAGES_CHERRYPICKS}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Extract buildcache URL from mirrors.yaml.in (simplified - get the version)
+          echo "buildcache-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
+      
       - name: Setup Spack
         uses: spack/setup-spack@v2.1.1
         with:
-          ref: develop
+          ref: ${{ steps.spack-config.outputs.spack-version }}
           color: true
           path: ${{ github.workspace }}/spack
+      
+      - name: Apply Spack cherry-picks
+        run: |
+          cd ${{ github.workspace }}/spack
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          
+          # Apply cherry-picks from spack.sh (match only valid git commit hashes)
+          echo "${{ steps.spack-config.outputs.spack-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
+            echo "Cherry-picking ${commit}"
+            git cherry-pick "${commit}"
+          done
+      
+      - name: Checkout and configure spack-packages
+        run: |
+          cd ${{ github.workspace }}/spack
+          git clone https://github.com/spack/spack-packages.git var/spack/repos/spack-packages
+          cd var/spack/repos/spack-packages
+          git checkout ${{ steps.spack-config.outputs.spackpackages-version }}
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          
+          # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
+          echo "${{ steps.spack-config.outputs.spackpackages-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
+            echo "Cherry-picking ${commit}"
+            git cherry-pick "${commit}"
+          done
+          
+          cd ${{ github.workspace }}/spack
+          spack repo add var/spack/repos/spack-packages
       
       - name: Add Spack environment
         run: |
           spack env create ci spack-environment/ci
           spack env activate ci
           spack -e ci compiler find
+          spack -e ci external find llvm
           spack -e ci external find --not-buildable cmake
       
       - name: Concretize
         run: |
           spack -e ci concretize -f
       
-      - name: Setup buildcache access
-        uses: spack/github-actions-buildcache@v2
-        with:
-          mode: readwrite
-          key: macos-${{ matrix.compiler }}-ci
+      - name: Configure buildcache
+        run: |
+          spack -e ci mirror add eic oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
+          spack -e ci buildcache keys --install --trust
       
       - name: Install
         run: |
           spack -e ci install --no-check-signature --show-log-on-error
-      
-      - name: Push to buildcache
-        if: always()
-        run: |
-          spack -e ci buildcache push --update-index --only=package --unsigned ${{ github.workspace }}/buildcache-macos
-      
-      - name: Show environment info
-        if: always()
-        run: |
-          spack -e ci find -lv
-          spack -e ci graph --dot > ci-graph.dot
-      
-      - name: Upload environment graph
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-environment-graph-${{ matrix.compiler }}
-          path: ci-graph.dot

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,79 @@
+name: macOS CI Build
+
+on:
+  push:
+    branches:
+      - master
+      - macos-ci-workflow
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Setup Spack
+        uses: spack/setup-spack@v2.1.1
+        with:
+          ref: develop
+          color: true
+          path: ${{ github.workspace }}/spack
+      
+      - name: Add Spack environment
+        run: |
+          spack env create ci spack-environment/ci
+          spack env activate ci
+          spack -e ci compiler find
+          spack -e ci external find --not-buildable cmake
+      
+      - name: Concretize
+        run: |
+          spack -e ci concretize -f
+      
+      - name: Setup buildcache access
+        uses: spack/github-actions-buildcache@v2
+        with:
+          mode: readwrite
+          key: macos-${{ matrix.compiler }}-ci
+      
+      - name: Install
+        run: |
+          spack -e ci install --no-check-signature --show-log-on-error
+      
+      - name: Push to buildcache
+        if: always()
+        run: |
+          spack -e ci buildcache push --update-index --only=package --unsigned ${{ github.workspace }}/buildcache-macos
+      
+      - name: Show environment info
+        if: always()
+        run: |
+          spack -e ci find -lv
+          spack -e ci graph --dot > ci-graph.dot
+      
+      - name: Upload environment graph
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-environment-graph-${{ matrix.compiler }}
+          path: ci-graph.dot

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Set Deployment Target to match runner SDK
+        run: |
+          # Fetch the active SDK version (e.g., 14.5)
+          CURRENT_SDK=$(xcrun --show-sdk-version)
+          
+          # Export it to the GitHub environment so all future steps use it
+          echo "MACOSX_DEPLOYMENT_TARGET=$CURRENT_SDK" >> $GITHUB_ENV
+
       - name: Extract Spack configuration
         id: spack-config
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -31,9 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+        uses: actions/checkout@v7
 
       - name: Extract Spack configuration
         id: spack-config
@@ -63,11 +61,16 @@ jobs:
           # Extract buildcache URL from mirrors.yaml.in (simplified - get the version)
           echo "buildcache-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Checkout and configure spack
+      - name: Checkout Spack repository
+        uses: actions/checkout@v7
+        with:
+          repo: https://github.com/spack/spack.git
+          path: ${{ github.workspace }}/spack
+          ref: ${{ steps.spack-config.outputs.spack-version }}
+
+      - name: Configure spack
         run: |
-          git clone --filter=tree:0 https://github.com/spack/spack.git ${{ github.workspace }}/spack
           cd ${{ github.workspace }}/spack
-          git checkout ${{ steps.spack-config.outputs.spack-version }}
           echo "${{ github.workspace }}/spack/bin" >> $GITHUB_PATH
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
@@ -82,12 +85,16 @@ jobs:
             git cherry-pick "${commit}"
           done < <(echo "${{ steps.spack-config.outputs.spack-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' || true)
 
-      - name: Checkout and configure spack-packages
+      - name: Checkout spack-packages repository
+        uses: actions/checkout@v7
+        with:
+          repo: https://github.com/spack/spack-packages.git
+          path: ${{ github.workspace }}/spack/var/spack/repos/spack-packages
+          ref: ${{ steps.spack-config.outputs.spackpackages-version }}
+
+      - name: Configure spack-packages
         run: |
-          cd ${{ github.workspace }}/spack
-          git clone --filter=tree:0 https://github.com/spack/spack-packages.git var/spack/repos/spack-packages
-          cd var/spack/repos/spack-packages
-          git checkout ${{ steps.spack-config.outputs.spackpackages-version }}
+          cd ${{ github.workspace }}/spack/var/spack/repos/spack-packages
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
@@ -104,23 +111,27 @@ jobs:
           cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/spack-packages/repos/spack_repo/builtin
 
-      - name: Checkout and configure key4hep-spack
-        run: |
-          cd ${{ github.workspace }}/spack
-          git clone --filter=tree:0 https://github.com/key4hep/key4hep-spack.git var/spack/repos/key4hep-spack
-          cd var/spack/repos/key4hep-spack
-          git checkout ${{ steps.spack-config.outputs.key4hepspack-version }}
+      - name: Checkout key4hep-spack repository
+        uses: actions/checkout@v7
+        with:
+          repo: https://github.com/key4hep/key4hep-spack.git
+          path: ${{ github.workspace }}/spack/var/spack/repos/key4hep-spack
+          ref: ${{ steps.spack-config.outputs.key4hepspack-version }}
 
+      - name: Configure key4hep-spack
+        run: |
           cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/key4hep-spack
 
-      - name: Checkout and configure eic-spack
-        run: |
-          cd ${{ github.workspace }}/spack
-          git clone --filter=tree:0 https://github.com/eic/eic-spack.git var/spack/repos/eic-spack
-          cd var/spack/repos/eic-spack
-          git checkout ${{ steps.spack-config.outputs.eicspack-version }}
+      - name: Checkout eic-spack repository
+        uses: actions/checkout@v7
+        with:
+          repo: https://github.com/eic/eic-spack.git
+          path: ${{ github.workspace }}/spack/var/spack/repos/eic-spack
+          ref: ${{ steps.spack-config.outputs.eicspack-version }}
 
+      - name: Configure eic-spack
+        run: |
           cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/eic-spack/spack_repo/eic
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - macos-ci-workflow
   pull_request:
     branches:
       - master

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -146,4 +146,4 @@ jobs:
 
       - name: Install epic environment
         run: |
-          spack -e spack-environment/${{matrix.ENV}}/epic -c view:false install install --no-check-signature --show-log-on-error
+          spack -e spack-environment/${{matrix.ENV}}/epic -c view:false install --no-check-signature --show-log-on-error

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Concretize
         run: |
-          spack -e spack-environment/${{matrix.ENV}} concretize -f
+          spack -e spack-environment/${{matrix.ENV}} -c view:false concretize --force
 
       - name: Configure buildcache
         run: |
@@ -134,7 +134,7 @@ jobs:
 
       - name: Install base environment
         run: |
-          spack -e spack-environment/${{matrix.ENV}} install --no-check-signature --show-log-on-error
+          spack -e spack-environment/${{matrix.ENV}} -c view:false install --no-check-signature --show-log-on-error
 
       - name: Install epic environment
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -64,9 +64,10 @@ jobs:
       - name: Checkout Spack repository
         uses: actions/checkout@v7
         with:
-          repo: https://github.com/spack/spack.git
-          path: ${{ github.workspace }}/spack
+          repository: spack/spack
+          path: spack
           ref: ${{ steps.spack-config.outputs.spack-version }}
+          fetch-depth: 0
 
       - name: Configure spack
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ENV: [ci, xl]
+        ENV: [ci, xl, tf]
 
     env:
       GITHUB_REGISTRY_USER: ${{ secrets.GHCR_REGISTRY_USER }}

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -76,6 +76,9 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
+          # Fetch branches from which we cherry-pick
+          git fetch origin pull/51584/head:pr-51584
+
           # Apply cherry-picks from spack.sh (match only valid git commit hashes)
           while read -r commit; do
             if git merge-base --is-ancestor "${commit}" HEAD; then

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -107,6 +107,7 @@ jobs:
           # Fetch branches from which we cherry-pick
           git fetch origin refs/heads/develop:refs/heads/develop
           git fetch origin pull/3698/head:pr-3698
+          git fetch origin pull/4871/head:pr-4871
 
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
           while read -r commit; do

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/spack
           git clone --filter=tree:0 https://github.com/key4hep/key4hep-spack.git var/spack/repos/key4hep-spack
+          cd var/spack/repos/key4hep-spack
           git checkout ${{ steps.spack-config.outputs.key4hepspack-version }}
           spack repo add var/spack/repos/key4hep-spack
 
@@ -106,6 +107,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/spack
           git clone --filter=tree:0 https://github.com/eic/eic-spack.git var/spack/repos/eic-spack
+          cd var/spack/repos/eic-spack
           git checkout ${{ steps.spack-config.outputs.eicspack-version }}
           spack repo add var/spack/repos/eic-spack/spack_repo/eic
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -108,6 +108,7 @@ jobs:
           git fetch origin refs/heads/develop:refs/heads/develop
           git fetch origin pull/3698/head:pr-3698
           git fetch origin pull/4871/head:pr-4871
+          git fetch origin pull/5856/head:pr-5856
 
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
           while read -r commit; do

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -22,9 +22,8 @@ jobs:
   build:
     runs-on: macos-latest
     strategy:
-      fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        ENV: [ci, xl]
 
     steps:
       - name: Checkout repository
@@ -91,21 +90,23 @@ jobs:
 
       - name: Add Spack environment
         run: |
-          spack env create ci spack-environment/ci
-          spack env activate ci
-          spack -e ci compiler find
-          spack -e ci external find llvm
-          spack -e ci external find --not-buildable cmake
+          spack env activate -d spack-environment/${{matrix.ENV}}
+          spack compiler find
+          spack external find llvm
+          spack external find --not-buildable cmake
 
       - name: Concretize
         run: |
-          spack -e ci concretize -f
+          spack env activate -d spack-environment/${{matrix.ENV}}
+          spack concretize -f
 
       - name: Configure buildcache
         run: |
-          spack -e ci mirror add eic oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
-          spack -e ci buildcache keys --install --trust
+          spack env activate -d spack-environment/${{matrix.ENV}}
+          spack mirror add eic oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
+          spack buildcache keys --install --trust
 
       - name: Install
         run: |
-          spack -e ci install --no-check-signature --show-log-on-error
+          spack env activate -d spack-environment/${{matrix.ENV}}
+          spack install --no-check-signature --show-log-on-error

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -24,6 +24,10 @@ jobs:
       matrix:
         ENV: [ci, xl]
 
+    env:
+      GITHUB_REGISTRY_USER: ${{ secrets.GHCR_REGISTRY_USER }}
+      GITHUB_REGISTRY_TOKEN: ${{ secrets.GHCR_REGISTRY_TOKEN }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -96,8 +100,11 @@ jobs:
       - name: Configure buildcache
         run: |
           spack env activate -d spack-environment/${{matrix.ENV}}
-          spack mirror add eic oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
-          spack buildcache keys --install --trust
+          spack mirror add eic \
+            --autopush --unsigned \
+            --oci-username-variable GITHUB_REGISTRY_USER \
+            --oci-password-variable GITHUB_REGISTRY_TOKEN \
+            oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
 
       - name: Install
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Checkout spack-packages repository
         uses: actions/checkout@v7
         with:
-          repo: https://github.com/spack/spack-packages.git
-          path: ${{ github.workspace }}/spack/var/spack/repos/spack-packages
+          repository: spack/spack-packages
+          path: spack/var/spack/repos/spack-packages
           ref: ${{ steps.spack-config.outputs.spackpackages-version }}
 
       - name: Configure spack-packages
@@ -115,8 +115,8 @@ jobs:
       - name: Checkout key4hep-spack repository
         uses: actions/checkout@v7
         with:
-          repo: https://github.com/key4hep/key4hep-spack.git
-          path: ${{ github.workspace }}/spack/var/spack/repos/key4hep-spack
+          repository: key4hep/key4hep-spack
+          path: spack/var/spack/repos/key4hep-spack
           ref: ${{ steps.spack-config.outputs.key4hepspack-version }}
 
       - name: Configure key4hep-spack
@@ -127,8 +127,8 @@ jobs:
       - name: Checkout eic-spack repository
         uses: actions/checkout@v7
         with:
-          repo: https://github.com/eic/eic-spack.git
-          path: ${{ github.workspace }}/spack/var/spack/repos/eic-spack
+          repository: eic/eic-spack
+          path: spack/var/spack/repos/eic-spack
           ref: ${{ steps.spack-config.outputs.eicspack-version }}
 
       - name: Configure eic-spack

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -21,6 +21,7 @@ jobs:
   build:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         ENV: [ci, xl]
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -87,7 +87,6 @@ jobs:
           spack env activate -d spack-environment/${{matrix.ENV}}
           spack compiler find
           spack external find llvm
-          spack external find --not-buildable cmake
 
       - name: Concretize
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -101,6 +101,8 @@ jobs:
           git clone --filter=tree:0 https://github.com/key4hep/key4hep-spack.git var/spack/repos/key4hep-spack
           cd var/spack/repos/key4hep-spack
           git checkout ${{ steps.spack-config.outputs.key4hepspack-version }}
+
+          cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/key4hep-spack
 
       - name: Checkout and configure eic-spack
@@ -109,6 +111,8 @@ jobs:
           git clone --filter=tree:0 https://github.com/eic/eic-spack.git var/spack/repos/eic-spack
           cd var/spack/repos/eic-spack
           git checkout ${{ steps.spack-config.outputs.eicspack-version }}
+
+          cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/eic-spack/spack_repo/eic
 
       - name: Add Spack environment

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -51,6 +51,14 @@ jobs:
           echo "${SPACKPACKAGES_CHERRYPICKS}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+          # Source key4hep-spack.sh to get KEY4HEPSPACK_VERSION
+          source key4hep-spack.sh
+          echo "key4hepspack-version=${KEY4HEPSPACK_VERSION}" >> $GITHUB_OUTPUT
+
+          # Source eic-spack.sh to get EICSPACK_VERSION
+          source eic-spack.sh
+          echo "eicspack-version=${EICSPACK_VERSION}" >> $GITHUB_OUTPUT
+
           # Extract buildcache URL from mirrors.yaml.in (simplified - get the version)
           echo "buildcache-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
 
@@ -85,7 +93,21 @@ jobs:
           done
 
           cd ${{ github.workspace }}/spack
-          spack repo add var/spack/repos/spack-packages
+          spack repo add var/spack/repos/spack-packages/repos/spack_repo/builtin
+
+      - name: Checkout and configure key4hep-spack
+        run: |
+          cd ${{ github.workspace }}/spack
+          git clone --filter=tree:0 https://github.com/key4hep-spack/key4hep-spack.git var/spack/repos/key4hep-spack
+          git checkout ${{ steps.spack-config.outputs.key4hepspack-version }}
+          spack repo add var/spack/repos/key4hep-spack
+
+      - name: Checkout and configure eic-spack
+        run: |
+          cd ${{ github.workspace }}/spack
+          git clone --filter=tree:0 https://github.com/eic/eic-spack.git var/spack/repos/eic-spack
+          git checkout ${{ steps.spack-config.outputs.eicspack-version }}
+          spack repo add var/spack/repos/eic-spack/spack_repo/eic
 
       - name: Add Spack environment
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -117,25 +117,25 @@ jobs:
 
       - name: Add Spack environment
         run: |
-          spack env activate -d spack-environment/${{matrix.ENV}}
-          spack compiler find
-          spack external find llvm
+          spack -e spack-environment/${{matrix.ENV}} compiler find
+          spack -e spack-environment/${{matrix.ENV}} external find llvm
 
       - name: Concretize
         run: |
-          spack env activate -d spack-environment/${{matrix.ENV}}
-          spack concretize -f
+          spack -e spack-environment/${{matrix.ENV}} concretize -f
 
       - name: Configure buildcache
         run: |
-          spack env activate -d spack-environment/${{matrix.ENV}}
-          spack mirror add eic \
+          spack -e spack-environment/${{matrix.ENV}} mirror add eic \
             --autopush --unsigned \
             --oci-username-variable GITHUB_REGISTRY_USER \
             --oci-password-variable GITHUB_REGISTRY_TOKEN \
             oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
 
-      - name: Install
+      - name: Install base environment
         run: |
-          spack env activate -d spack-environment/${{matrix.ENV}}
-          spack install --no-check-signature --show-log-on-error
+          spack -e spack-environment/${{matrix.ENV}} install --no-check-signature --show-log-on-error
+
+      - name: Install epic environment
+        run: |
+          spack -e spack-environment/${{matrix.ENV}}/epic install --no-check-signature --show-log-on-error

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -72,10 +72,14 @@ jobs:
           git config user.email "actions@github.com"
 
           # Apply cherry-picks from spack.sh (match only valid git commit hashes)
-          echo "${{ steps.spack-config.outputs.spack-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
+          while read -r commit; do
+            if git merge-base --is-ancestor "${commit}" HEAD; then
+              echo "Skipping already applied ${commit}"
+              continue
+            fi
             echo "Cherry-picking ${commit}"
             git cherry-pick "${commit}"
-          done
+          done < <(echo "${{ steps.spack-config.outputs.spack-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' || true)
 
       - name: Checkout and configure spack-packages
         run: |
@@ -87,10 +91,14 @@ jobs:
           git config user.email "actions@github.com"
 
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
-          echo "${{ steps.spack-config.outputs.spackpackages-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
+          while read -r commit; do
+            if git merge-base --is-ancestor "${commit}" HEAD; then
+              echo "Skipping already applied ${commit}"
+              continue
+            fi
             echo "Cherry-picking ${commit}"
             git cherry-pick "${commit}"
-          done
+          done < <(echo "${{ steps.spack-config.outputs.spackpackages-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' || true)
 
           cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/spack-packages/repos/spack_repo/builtin

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -106,6 +106,7 @@ jobs:
 
           # Fetch branches from which we cherry-pick
           git fetch origin refs/heads/develop:refs/heads/develop
+          git fetch origin pull/3698/head:pr-3698
 
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
           while read -r commit; do

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -56,9 +56,10 @@ jobs:
 
       - name: Checkout and configure spack
         run: |
-          git clone --filter=tree:0 https://github.com/spack/spack-packages.git ${{ github.workspace }}/spack
+          git clone --filter=tree:0 https://github.com/spack/spack.git ${{ github.workspace }}/spack
           cd ${{ github.workspace }}/spack
           git checkout ${{ steps.spack-config.outputs.spack-version }}
+          echo "${{ github.workspace }}/spack/bin" >> $GITHUB_PATH
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -78,6 +78,7 @@ jobs:
 
           # Fetch branches from which we cherry-pick
           git fetch origin pull/51584/head:pr-51584
+          git fetch origin pull/52207/head:pr-52207
 
           # Apply cherry-picks from spack.sh (match only valid git commit hashes)
           while read -r commit; do

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Checkout and configure key4hep-spack
         run: |
           cd ${{ github.workspace }}/spack
-          git clone --filter=tree:0 https://github.com/key4hep-spack/key4hep-spack.git var/spack/repos/key4hep-spack
+          git clone --filter=tree:0 https://github.com/key4hep/key4hep-spack.git var/spack/repos/key4hep-spack
           git checkout ${{ steps.spack-config.outputs.key4hepspack-version }}
           spack repo add var/spack/repos/key4hep-spack
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -138,4 +138,4 @@ jobs:
 
       - name: Install epic environment
         run: |
-          spack -e spack-environment/${{matrix.ENV}}/epic install --no-check-signature --show-log-on-error
+          spack -e spack-environment/${{matrix.ENV}}/epic -c view:false install install --no-check-signature --show-log-on-error

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -77,6 +77,7 @@ jobs:
           git config user.email "actions@github.com"
 
           # Fetch branches from which we cherry-pick
+          git fetch origin refs/heads/develop:refs/heads/develop
           git fetch origin pull/51584/head:pr-51584
           git fetch origin pull/52207/head:pr-52207
 
@@ -102,6 +103,9 @@ jobs:
           cd ${{ github.workspace }}/spack/var/spack/repos/spack-packages
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+
+          # Fetch branches from which we cherry-pick
+          git fetch origin refs/heads/develop:refs/heads/develop
 
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
           while read -r commit; do

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           # Fetch the active SDK version (e.g., 14.5)
           CURRENT_SDK=$(xcrun --show-sdk-version)
-          
+
           # Export it to the GitHub environment so all future steps use it
           echo "MACOSX_DEPLOYMENT_TARGET=$CURRENT_SDK" >> $GITHUB_ENV
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -149,24 +149,28 @@ jobs:
 
       - name: Add Spack environment
         run: |
-          spack -e spack-environment/${{matrix.ENV}} compiler find
-          spack -e spack-environment/${{matrix.ENV}} external find llvm
-
-      - name: Concretize
-        run: |
-          spack -e spack-environment/${{matrix.ENV}} -c view:false concretize --force
+          spack compiler find --scope site
+          spack external find --scope site llvm
 
       - name: Configure buildcache
         run: |
-          spack -e spack-environment/${{matrix.ENV}} mirror add eic \
+          spack mirror add --scope site eic \
             --autopush --unsigned \
             --oci-username-variable GITHUB_REGISTRY_USER \
             --oci-password-variable GITHUB_REGISTRY_TOKEN \
             oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
 
+      - name: Concretize base environment
+        run: |
+          spack -e spack-environment/${{matrix.ENV}} -c view:false concretize --force
+
       - name: Install base environment
         run: |
           spack -e spack-environment/${{matrix.ENV}} -c view:false install --no-check-signature --show-log-on-error
+
+      - name: Concretize epic environment
+        run: |
+          spack -e spack-environment/${{matrix.ENV}}/epic -c view:false concretize --force
 
       - name: Install epic environment
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -51,16 +51,11 @@ jobs:
           # Extract buildcache URL from mirrors.yaml.in (simplified - get the version)
           echo "buildcache-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Setup Spack
-        uses: spack/setup-spack@v2.1.1
-        with:
-          ref: ${{ steps.spack-config.outputs.spack-version }}
-          color: true
-          path: ${{ github.workspace }}/spack
-
-      - name: Apply Spack cherry-picks
+      - name: Checkout and configure spack
         run: |
+          git clone --filter=tree:0 https://github.com/spack/spack-packages.git ${{ github.workspace }}/spack
           cd ${{ github.workspace }}/spack
+          git checkout ${{ steps.spack-config.outputs.spack-version }}
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
@@ -73,7 +68,7 @@ jobs:
       - name: Checkout and configure spack-packages
         run: |
           cd ${{ github.workspace }}/spack
-          git clone https://github.com/spack/spack-packages.git var/spack/repos/spack-packages
+          git clone --filter=tree:0 https://github.com/spack/spack-packages.git var/spack/repos/spack-packages
           cd var/spack/repos/spack-packages
           git checkout ${{ steps.spack-config.outputs.spackpackages-version }}
           git config user.name "GitHub Actions"

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -25,13 +25,13 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      
+
       - name: Extract Spack configuration
         id: spack-config
         run: |
@@ -41,36 +41,36 @@ jobs:
           echo "spack-cherrypicks<<EOF" >> $GITHUB_OUTPUT
           echo "${SPACK_CHERRYPICKS}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          
+
           # Source spack-packages.sh to get SPACKPACKAGES_VERSION and SPACKPACKAGES_CHERRYPICKS
           source spack-packages.sh
           echo "spackpackages-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
           echo "spackpackages-cherrypicks<<EOF" >> $GITHUB_OUTPUT
           echo "${SPACKPACKAGES_CHERRYPICKS}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-          
+
           # Extract buildcache URL from mirrors.yaml.in (simplified - get the version)
           echo "buildcache-version=${SPACKPACKAGES_VERSION}" >> $GITHUB_OUTPUT
-      
+
       - name: Setup Spack
         uses: spack/setup-spack@v2.1.1
         with:
           ref: ${{ steps.spack-config.outputs.spack-version }}
           color: true
           path: ${{ github.workspace }}/spack
-      
+
       - name: Apply Spack cherry-picks
         run: |
           cd ${{ github.workspace }}/spack
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          
+
           # Apply cherry-picks from spack.sh (match only valid git commit hashes)
           echo "${{ steps.spack-config.outputs.spack-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
             echo "Cherry-picking ${commit}"
             git cherry-pick "${commit}"
           done
-      
+
       - name: Checkout and configure spack-packages
         run: |
           cd ${{ github.workspace }}/spack
@@ -79,16 +79,16 @@ jobs:
           git checkout ${{ steps.spack-config.outputs.spackpackages-version }}
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          
+
           # Apply cherry-picks from spack-packages.sh (match only valid git commit hashes)
           echo "${{ steps.spack-config.outputs.spackpackages-cherrypicks }}" | grep -E '^[a-f0-9]{40}$' | while read -r commit; do
             echo "Cherry-picking ${commit}"
             git cherry-pick "${commit}"
           done
-          
+
           cd ${{ github.workspace }}/spack
           spack repo add var/spack/repos/spack-packages
-      
+
       - name: Add Spack environment
         run: |
           spack env create ci spack-environment/ci
@@ -96,16 +96,16 @@ jobs:
           spack -e ci compiler find
           spack -e ci external find llvm
           spack -e ci external find --not-buildable cmake
-      
+
       - name: Concretize
         run: |
           spack -e ci concretize -f
-      
+
       - name: Configure buildcache
         run: |
           spack -e ci mirror add eic oci://ghcr.io/eic/spack-${{ steps.spack-config.outputs.buildcache-version }}
           spack -e ci buildcache keys --install --trust
-      
+
       - name: Install
         run: |
           spack -e ci install --no-check-signature --show-log-on-error

--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -5,6 +5,18 @@ spack:
   - ../packages.yaml
   - ../packages_root_without_opengl.yaml
   - ../view.yaml
+  definitions:
+  # Note that in definitions 'when' takes a python expression as argument
+  # https://spack.readthedocs.io/en/latest/environments.html#spec-list-references
+  - when: arch.satisfies("platform=linux")
+    linux_packages: 
+    - imagemagick
+    - nopayloadclient
+    - ollama
+    - py-numpy
+    - py-scipy
+  - when: arch.satisfies("platform=darwin")
+    linux_packages: []
   specs:
   - acts
   - actsvg
@@ -24,15 +36,12 @@ spack:
   - hepmc3
   - hepmcmerger
   - heppdt
-  - imagemagick
   - irt
   - irt2
   - iwyu
   - jana2
   - just
-  - nopayloadclient
   - npsim -geocad
-  - ollama
   - onnx
   - osg-ca-certs
   - pelican
@@ -58,14 +67,12 @@ spack:
   - py-matplotlib
   - py-mplhep
   - py-htgettoken
-  - py-numpy
   - py-onnx
   - py-onnxruntime
   - py-pandas
   - py-particle
   - py-pip
   - py-rucio-clients
-  - py-scipy
   - py-seaborn
   - py-snakemake-storage-plugin-fs
   - py-snakemake-storage-plugin-pelican

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -281,10 +281,16 @@ packages:
     - ~gtk
   gl:
     require:
-    - glx
+    - spec: glx
+      when: platform=linux
+    - spec: apple-gl
+      when: platform=darwin
   glu:
     require:
-    - openglu
+    - spec: openglu
+      when: platform=linux
+    - spec: apple-glu
+      when: platform=darwin
   gloo:
     require:
     - '@2023-12-03'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -657,17 +657,11 @@ packages:
   qt:
     require:
     - '@5.15.12:'
-    - spec: +opengl
-      when: platform=linux
-    - spec: ~opengl
-      when: platform=darwin
+    - +opengl
   qt-base:
     require:
     - '@6.7.2:'
-    - spec: +opengl
-      when: platform=linux
-    - spec: ~opengl
-      when: platform=darwin
+    - +opengl
   rdma-core:
     require:
     - ~pyverbs  # avoid constraint in https://github.com/spack/spack-packages/pull/2791

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -73,14 +73,26 @@ packages:
     - cxxstd=20
   c:
     prefer:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
     require:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
   cxx:
     prefer:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
     require:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
   cairo:
     require:
     - '@1.18.2:'
@@ -202,9 +214,15 @@ packages:
     - +shared cxxstd=20
   fortran:
     prefer:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
     require:
-    - gcc
+    - spec: gcc
+      when: platform=linux
+    - spec: clang
+      when: platform=darwin
   freetype:
     require:
     - build_system=autotools

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -267,6 +267,8 @@ packages:
     - '@11.4.1.east'
     - cxxstd=20 -vecgeom +threads -vtk
     - any_of: [+opengl +qt +x11, -opengl -qt -x11]
+    - spec: -opengl -qt -x11
+      when: platform=darwin
   geant4-data:
     require:
     - +nudexlib +tendl +urrpt
@@ -651,11 +653,17 @@ packages:
   qt:
     require:
     - '@5.15.12:'
-    - +opengl
+    - spec: +opengl
+      when: platform=linux
+    - spec: ~opengl
+      when: platform=darwin
   qt-base:
     require:
     - '@6.7.2:'
-    - +opengl
+    - spec: +opengl
+      when: platform=linux
+    - spec: ~opengl
+      when: platform=darwin
   rdma-core:
     require:
     - ~pyverbs  # avoid constraint in https://github.com/spack/spack-packages/pull/2791
@@ -668,6 +676,8 @@ packages:
     - '@6.40.02'
     - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
+    - spec: -opengl -webgui
+      when: platform=darwin
   sherpa:
     require:
     - '@3.0.1'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -672,9 +672,11 @@ packages:
   root:
     require:
     - '@6.40.02'
-    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
+    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
-    - spec: -opengl -webgui
+    - spec: +x
+      when: platform=linux
+    - spec: ~x
       when: platform=darwin
   sherpa:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -75,23 +75,23 @@ packages:
     prefer:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: apple-clang
       when: platform=darwin
     require:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: apple-clang
       when: platform=darwin
   cxx:
     prefer:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: apple-clang
       when: platform=darwin
     require:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: apple-clang
       when: platform=darwin
   cairo:
     require:
@@ -216,12 +216,12 @@ packages:
     prefer:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: gcc
       when: platform=darwin
     require:
     - spec: gcc
       when: platform=linux
-    - spec: clang
+    - spec: gcc
       when: platform=darwin
   freetype:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -266,8 +266,12 @@ packages:
     require:
     - '@11.4.1.east'
     - cxxstd=20 -vecgeom +threads -vtk
-    - any_of: [+opengl +qt +x11, -opengl -qt -x11]
-    - spec: -opengl -qt -x11
+    - any_of: [+opengl +qt, -opengl -qt]
+    - spec: ~x11
+      when: ~opengl platform=linux
+    - spec: +x11
+      when: +opengl platform=linux
+    - spec: ~x11
       when: platform=darwin
   geant4-data:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -60,7 +60,7 @@ packages:
     - +brotli +bz2 +dataset +filesystem +glog +ipc +jemalloc +lz4 +parquet +snappy +zlib +zstd
   binutils:
     require:
-    - ~gold
+    - '@2.44:'
   blas:
     require:
     - openblas

--- a/spack-environment/tf/spack.yaml
+++ b/spack-environment/tf/spack.yaml
@@ -4,7 +4,13 @@ spack:
   - ../config.yaml
   - ../packages.yaml
   - ../view.yaml
+  definitions:
+  - when: arch.satisfies("platform=linux")
+    tensorflow: [py-tensorflow +cuda]
+  - when: arch.satisfies("platform=darwin")
+    tensorflow: [py-tensorflow ~cuda]
   specs:
+  - $tensorflow
   - edm4hep
   - onnx
   - osg-ca-certs
@@ -42,7 +48,6 @@ spack:
   - py-rucio-clients
   - py-scipy
   - py-seaborn
-  - py-tensorflow +cuda
   - py-tf2onnx
   - py-toml
   - py-uproot

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -9,11 +9,11 @@ spack:
   # Note that in definitions 'when' takes a python expression as argument
   # https://spack.readthedocs.io/en/latest/environments.html#spec-list-references
   - when: arch.satisfies("platform=linux")
-    extra_packages: [strace]
+    linux_packages: [strace, valgrind]
   - when: arch.satisfies("platform=darwin")
-    extra_packages: []
+    linux_packages: []
   specs:
-  - $extra_packages
+  - $linux_packages
   - acts
   - actsvg
   - afterburner
@@ -141,7 +141,6 @@ spack:
   - snakemake
   - spdlog
   - stow
-  - valgrind
   - xeyes
   - xrootd
   - xrootd-mcp-server

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -6,6 +6,8 @@ spack:
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
   definitions:
+  # Note that in definitions, when takes a python expression as argument
+  # https://spack.readthedocs.io/en/latest/environments.html#spec-list-references
   - when: arch.satisfies("platform=linux")
     extra_packages: [strace]
   - when: arch.satisfies("platform=darwin")

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -6,7 +6,7 @@ spack:
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
   definitions:
-  # Note that in definitions, when takes a python expression as argument
+  # Note that in definitions 'when' takes a python expression as argument
   # https://spack.readthedocs.io/en/latest/environments.html#spec-list-references
   - when: arch.satisfies("platform=linux")
     extra_packages: [strace]

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -133,7 +133,8 @@ spack:
   - snakemake
   - spdlog
   - stow
-  - strace
+  - spec: strace
+    when: platform=linux
   - valgrind
   - xeyes
   - xrootd

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -5,7 +5,13 @@ spack:
   - ../packages.yaml
   - ../packages_root_with_opengl.yaml
   - ../view.yaml
+  definitions:
+  - when: arch.satisfies("platform=linux")
+    extra_packages: [strace]
+  - when: arch.satisfies("platform=darwin")
+    extra_packages: []
   specs:
+  - $extra_packages
   - acts
   - actsvg
   - afterburner
@@ -133,8 +139,6 @@ spack:
   - snakemake
   - spdlog
   - stow
-  - spec: strace
-    when: platform=linux
   - valgrind
   - xeyes
   - xrootd

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -18,7 +18,7 @@ deb4f17d93dbe012403614245334f7c73fcc086f
 82a6d07a37d13c247e84417055f9cb5b4802ac4f
 47780b2c59a8356c1f13cd7c8d250e3250c15ba8
 28bd1a044251fca35e14ba55d7ddb567deadcdaa
-a7c32f24cd5b69b237dc974804a71326306f4e58
+72269859719d77f986be7cc752946650d020ac3f
 de97f131df3dbc940151f406afd5c2c1158a660c
 caf013be0ee1594fdbba8feb07ffecc88474a2b0
 75395349957ad785cca50002dffb18bbcb48af27
@@ -42,7 +42,7 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 82a6d07a37d13c247e84417055f9cb5b4802ac4f: osg-ca-certs: depends on gmake and perl, type build
 ## 47780b2c59a8356c1f13cd7c8d250e3250c15ba8: py-pynacl: depends on gmake, type build
 ## 28bd1a044251fca35e14ba55d7ddb567deadcdaa: py-throttler: add v1.2.3
-## a7c32f24cd5b69b237dc974804a71326306f4e58: py-tensorboard: add v2.21.0
+## 72269859719d77f986be7cc752946650d020ac3f: py-tensorboard: add v2.21.0
 ## de97f131df3dbc940151f406afd5c2c1158a660c: TensorFlow: add v2.21.0
 ## caf013be0ee1594fdbba8feb07ffecc88474a2b0: Add missing xxd dep
 ## 75395349957ad785cca50002dffb18bbcb48af27: py-torch: ensure setuptools is not unnecessarily constrained for 2.10:

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -13,7 +13,6 @@ SPACKPACKAGES_VERSION="v2026.06.0"
 read -r -d '' SPACKPACKAGES_CHERRYPICKS <<- \
 --- || true
 384fd54caf18c6393607bff018853747d02c6e0f
-20444b8e9382e659360a1446688d10a8c2d2ad31
 f5742718da7bd1d078ddc8423011a82ef2e3c759
 deb4f17d93dbe012403614245334f7c73fcc086f
 82a6d07a37d13c247e84417055f9cb5b4802ac4f
@@ -38,7 +37,6 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## Ref: https://github.com/spack/spack-packages/commit/[hash]
 ## [hash]: [description]
 ## 384fd54caf18c6393607bff018853747d02c6e0f: github-copilot: new package
-## 20444b8e9382e659360a1446688d10a8c2d2ad31: github-copilot: add v1.0.8
 ## f5742718da7bd1d078ddc8423011a82ef2e3c759: gaudi: workaround test-dependency bug with a when
 ## deb4f17d93dbe012403614245334f7c73fcc086f: fix: add latest osg-ca-cert
 ## 82a6d07a37d13c247e84417055f9cb5b4802ac4f: osg-ca-certs: depends on gmake and perl, type build

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -13,7 +13,7 @@ SPACKPACKAGES_VERSION="v2026.06.0"
 read -r -d '' SPACKPACKAGES_CHERRYPICKS <<- \
 --- || true
 384fd54caf18c6393607bff018853747d02c6e0f
-f5742718da7bd1d078ddc8423011a82ef2e3c759
+bd9b4838fbf9e4ca01ad7b6c6df633ddcc750d71
 deb4f17d93dbe012403614245334f7c73fcc086f
 82a6d07a37d13c247e84417055f9cb5b4802ac4f
 47780b2c59a8356c1f13cd7c8d250e3250c15ba8
@@ -37,7 +37,7 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## Ref: https://github.com/spack/spack-packages/commit/[hash]
 ## [hash]: [description]
 ## 384fd54caf18c6393607bff018853747d02c6e0f: github-copilot: new package
-## f5742718da7bd1d078ddc8423011a82ef2e3c759: gaudi: workaround test-dependency bug with a when
+## bd9b4838fbf9e4ca01ad7b6c6df633ddcc750d71: gaudi: workaround test-dependency bug with a when
 ## deb4f17d93dbe012403614245334f7c73fcc086f: fix: add latest osg-ca-cert
 ## 82a6d07a37d13c247e84417055f9cb5b4802ac4f: osg-ca-certs: depends on gmake and perl, type build
 ## 47780b2c59a8356c1f13cd7c8d250e3250c15ba8: py-pynacl: depends on gmake, type build

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -19,8 +19,9 @@ deb4f17d93dbe012403614245334f7c73fcc086f
 47780b2c59a8356c1f13cd7c8d250e3250c15ba8
 28bd1a044251fca35e14ba55d7ddb567deadcdaa
 72269859719d77f986be7cc752946650d020ac3f
-de97f131df3dbc940151f406afd5c2c1158a660c
-caf013be0ee1594fdbba8feb07ffecc88474a2b0
+125ca0c4f3b8bb2c5312c571e27006d9ddc06085
+7a6fa1c4f62f27531c93ecfeedad30181e9616f9
+c72830c64ceda0390b12e0b7ddda6418fa3806be
 75395349957ad785cca50002dffb18bbcb48af27
 acac89d6bb7079412e711a50a3f06681132a2723
 438abd1e09f0cea9cb0ccc7e0326adcd0408196b
@@ -43,8 +44,9 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 47780b2c59a8356c1f13cd7c8d250e3250c15ba8: py-pynacl: depends on gmake, type build
 ## 28bd1a044251fca35e14ba55d7ddb567deadcdaa: py-throttler: add v1.2.3
 ## 72269859719d77f986be7cc752946650d020ac3f: py-tensorboard: add v2.21.0
-## de97f131df3dbc940151f406afd5c2c1158a660c: TensorFlow: add v2.21.0
-## caf013be0ee1594fdbba8feb07ffecc88474a2b0: Add missing xxd dep
+## 125ca0c4f3b8bb2c5312c571e27006d9ddc06085: TensorFlow: add v2.21.0
+## 7a6fa1c4f62f27531c93ecfeedad30181e9616f9: Add missing xxd dep
+## c72830c64ceda0390b12e0b7ddda6418fa3806be: Workaround for macOS arm64 compile bug
 ## 75395349957ad785cca50002dffb18bbcb48af27: py-torch: ensure setuptools is not unnecessarily constrained for 2.10:
 ## acac89d6bb7079412e711a50a3f06681132a2723: cuda: append --allow-unsupported-compiler to CUDAFLAGS for dependent_spec
 ## 438abd1e09f0cea9cb0ccc7e0326adcd0408196b: herwig3: add CT14(?n)lo pdfsets as build-time resources

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -12,7 +12,7 @@ SPACKPACKAGES_VERSION="v2026.06.0"
 ## Space-separated list of spack-packages cherry-picks
 read -r -d '' SPACKPACKAGES_CHERRYPICKS <<- \
 --- || true
-a115a811bdfce4db5298a9ba9b7903ccfb0de101
+384fd54caf18c6393607bff018853747d02c6e0f
 20444b8e9382e659360a1446688d10a8c2d2ad31
 f5742718da7bd1d078ddc8423011a82ef2e3c759
 deb4f17d93dbe012403614245334f7c73fcc086f
@@ -37,7 +37,7 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ---
 ## Ref: https://github.com/spack/spack-packages/commit/[hash]
 ## [hash]: [description]
-## a115a811bdfce4db5298a9ba9b7903ccfb0de101: github-copilot: new package
+## 384fd54caf18c6393607bff018853747d02c6e0f: github-copilot: new package
 ## 20444b8e9382e659360a1446688d10a8c2d2ad31: github-copilot: add v1.0.8
 ## f5742718da7bd1d078ddc8423011a82ef2e3c759: gaudi: workaround test-dependency bug with a when
 ## deb4f17d93dbe012403614245334f7c73fcc086f: fix: add latest osg-ca-cert

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -27,6 +27,7 @@ acac89d6bb7079412e711a50a3f06681132a2723
 438abd1e09f0cea9cb0ccc7e0326adcd0408196b
 d4fb37cedfb7552a753bdc9c0c4792082f4b46e8
 4dc856a13e9066ca3249a593d351af8cda521fa3
+3dcad5bb860184c91c17b97a9f3b13252d26d309
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -51,3 +52,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 438abd1e09f0cea9cb0ccc7e0326adcd0408196b: herwig3: add CT14(?n)lo pdfsets as build-time resources
 ## d4fb37cedfb7552a753bdc9c0c4792082f4b46e8: py-tensorflow: add libclang variant
 ## 4dc856a13e9066ca3249a593d351af8cda521fa3: root: add v6.40.00, v6.40.02
+## 3dcad5bb860184c91c17b97a9f3b13252d26d309: readline: switch url for patch download

--- a/spack.sh
+++ b/spack.sh
@@ -11,7 +11,7 @@ SPACK_VERSION="v1.2.2"
 read -r -d '' SPACK_CHERRYPICKS <<- \
 --- || true
 292b0dcaba3b2a5e3f9668d205d39fee2c715721
-678e506a95b319c573ba7e84703b06d7275ab80e
+473d1459fba532de0d3d7edc34d27b1432bc90cd
 ---
 ## Optional hash table with comma-separated file list
 read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
@@ -20,4 +20,4 @@ read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
 ## Ref: https://github.com/spack/spack/commit/[hash]
 ## [hash]: [description]
 ## 292b0dcaba3b2a5e3f9668d205d39fee2c715721: fix: write created time field with OCI buildcache config
-## 678e506a95b319c573ba7e84703b06d7275ab80e: fix: don't map prefix to view root for pkgs excluded from view
+## 473d1459fba532de0d3d7edc34d27b1432bc90cd: fix: don't map prefix to view root for pkgs excluded from view


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build the `ci`, `tf`, and `xl` environments on macOS.

## Features
- Matrix strategy testing `ci`, `tf`, and `xl` environments
- Automatic buildcache push/pull for faster rebuilds