### PR TITLE
feat: better resilience against listing already included cherry-picks

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -175,7 +175,7 @@ if [ -n "${SPACK_CHERRYPICKS}" ] ; then
   eval "declare -A SPACK_CHERRYPICKS_FILES_ARRAY=(${SPACK_CHERRYPICKS_FILES})"
   for hash in ${SPACK_CHERRYPICKS} ; do
     if git -C ${SPACK_ROOT} merge-base --is-ancestor "${hash}" HEAD ; then
-      echo "Skipping already-applied ${hash}"
+      echo "Skipping already applied ${hash}"
       continue
     fi
     if [ -n "${SPACK_CHERRYPICKS_FILES_ARRAY[${hash}]+found}" ] ; then
@@ -217,7 +217,7 @@ if [ -n "${SPACKPACKAGES_CHERRYPICKS}" ] ; then
   eval "declare -A SPACKPACKAGES_CHERRYPICKS_FILES_ARRAY=(${SPACKPACKAGES_CHERRYPICKS_FILES})"
   for hash in ${SPACKPACKAGES_CHERRYPICKS} ; do
     if git -C ${SPACKPACKAGES_ROOT} merge-base --is-ancestor "${hash}" HEAD ; then
-      echo "Skipping already-applied ${hash}"
+      echo "Skipping already applied ${hash}"
       continue
     fi
     if [ -n "${SPACKPACKAGES_CHERRYPICKS_FILES_ARRAY[${hash}]+found}" ] ; then


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR is a quality-of-life improvement in advance of #35. It is always a bit annoying to figure out which of the cherry-picks need to be retained. This PR will print the ones that can be dropped, but more importantly it won't fail on them when cherry-pick wants to apply them again (since they will be skipped).