### PR TITLE
fix: pyrobird ~batch

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -352,7 +352,7 @@ packages:
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'
-      message: "through at least 0.2.6, +batch requires py-pyppeteer which requires py-urllib3@1"
+      message: "Through at least 0.2.6, +batch requires py-pyppeteer which requires py-urllib3@1"
   pythia8:
     require:
     - '@8.315'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that pyrobird avoids the batch functionality which pulls in old versions of urllib3.