### PR TITLE
fix: yoda: require: @2.1.0:

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -570,6 +570,9 @@ packages:
     require:
     - '@5.7.0:'
     - cxxstd=20 -davix +python +scitokens-cpp
+  yoda:
+    require:
+    - '@2.1.0:'
   zlib-api:
     require:
     - zlib-ng


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updated `yoda` to 2.1.0 (or newer). Note: `yoda` is a dependency of `rivet`.