### PR TITLE
chore: py-torch-2.7.1

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -504,8 +504,8 @@ packages:
     require:
     - '@2.7.1:'
     - -mkldnn
-    - # avoid compilation error in third_party/XNNPACK/src/f16-avgpool/f16-avgpool-9p8x-minmax-neonfp16arith-c8.c
-      spec: cxxflags=-Wno-error=incompatible-pointer-types
+    # avoid compilation error in third_party/XNNPACK/src/f16-avgpool/f16-avgpool-9p8x-minmax-neonfp16arith-c8.c
+    - spec: cxxflags=-Wno-error=incompatible-pointer-types
       when: 'target=aarch64:'
   py-vector:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -502,7 +502,7 @@ packages:
     - '@0.10.2:'
   py-torch:
     require:
-    - '@2.5.1'
+    - '@2.7.1:'
     - -mkldnn
   py-vector:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -504,6 +504,9 @@ packages:
     require:
     - '@2.7.1:'
     - -mkldnn
+    - # avoid compilation error in third_party/XNNPACK/src/f16-avgpool/f16-avgpool-9p8x-minmax-neonfp16arith-c8.c
+      spec: cxxflags=-Wno-error=incompatible-pointer-types
+      when: 'target=aarch64:'
   py-vector:
     require:
     - '@1.5.1:'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -505,7 +505,7 @@ packages:
     - '@2.7.1:'
     - -mkldnn
     # avoid compilation error in third_party/XNNPACK/src/f16-avgpool/f16-avgpool-9p8x-minmax-neonfp16arith-c8.c
-    - spec: cxxflags=-Wno-error=incompatible-pointer-types
+    - spec: ~xnnpack
       when: 'target=aarch64:'
   py-vector:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades py-torch to 2.7.1 or later (to unpin py-sympy used by acts, and to support newer CUDA).