### PR TITLE
fix: avoid bootstrapping in all environments by doing it in base

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -258,6 +258,12 @@ spack compiler find --scope site
 spack config blame compilers
 EOF
 
+## Bootstrap
+RUN <<EOF
+spack bootstrap root /opt/spack/bootstrap
+spack bootstrap now
+EOF
+
 ## Setup buildcache mirrors
 ## - this always adds the read-only mirror to the container
 ## - the write-enabled mirror is provided later as a secret mount

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -260,6 +260,7 @@ EOF
 
 ## Bootstrap
 RUN <<EOF
+set -e
 spack bootstrap root /opt/spack/bootstrap
 spack bootstrap now
 EOF


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR moves the bootstrapping from every environment build into the base image build.