### PR TITLE
fix: avoid finding externals in all environments by doing it in base

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -265,6 +265,15 @@ spack bootstrap root /opt/spack/bootstrap
 spack bootstrap now
 EOF
 
+## Find external packages (if not already found as compilers)
+## - allow llvm to be buildable for py-numba > py-llvmlite
+RUN <<EOF
+set -e
+spack external find --scope site llvm
+spack external find --scope site --not-buildable gcc
+spack external find --scope site --not-buildable --path /usr/local/cuda/bin cuda
+EOF
+
 ## Setup buildcache mirrors
 ## - this always adds the read-only mirror to the container
 ## - the write-enabled mirror is provided later as a secret mount

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -53,8 +53,6 @@ ENV GIT_TERMINAL_PROMPT=0
 RUN <<EOF
 set -e
 spack env activate --without-view --dir ${SPACK_ENV}
-spack external find --not-buildable --scope env:${SPACK_ENV} --path /usr/local/cuda/bin cuda
-spack external find --scope env:${SPACK_ENV} llvm
 spack concretize --force
 spack --color=never find --long --no-groups --show-concretized --format "{name}" \
 | uniq -D -f2 | grep -v -w -e "\(epic\|llvm\|py-setuptools\|py-urllib3\)" \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR moves the finding of externals from every environment build into the base image build.