### PR TITLE
hotfix: revert "feat: move from two-track to three-track container build (#115)"

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -406,7 +406,7 @@ jobs:
           arch: amd64
           runner: ubuntu-latest
           PLATFORM: linux/amd64
-          target: builder_concretization_custom
+          target: builder_concretization_default
       fail-fast: false
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -6,9 +6,9 @@ ARG RUNTIME_IMAGE="debian_stable_base"
 ARG INTERNAL_TAG="master"
 
 ##
-## This docker build follows three tracks, in order to ensure that we build all packages
+## This docker build follows two tracks, in order to ensure that we build all packages
 ## in a builder image, but install them in a runtime image, while at the same time
-## avoiding an expensive filesystem copy operation at the end that breaks layering.
+## avoiding a expensive filesystem copy operation at the end that breaks layering.
 ##
 ## The build is split in an infrequently-changing default environment, upon which
 ## an environment with custom versions (e.g. individual commits) is layered. The
@@ -18,20 +18,15 @@ ARG INTERNAL_TAG="master"
 ## The separation in a builder and runtime image is particularly relevant to end up with
 ## lightweight images for expensive build dependencies, such as for example CUDA.
 ##
-## builder track:                        runtime track:
-## concretization:     installation:     concretization/installation:
-## ---------------------------------------------------------------------------------------
+## builder track                         runtime track
+## ----------------------------------------------------------------------
 ## builder_image                         runtime_image
 ## builder_concretization_default   
-##                \->  builder_installation_default
-##                                       runtime_default
-##                                       (copy spack.lock from builder_installation_default)
-##                                       (install via buildcache)
-## \->  builder_concretization_custom
-##                     \->  builder_installation_custom
-##                                       \->   runtime_custom
-##                                             (copy spack.lock from builder_installation_custom)
-##                                             (install via buildcache)
+## builder_installation_default     ->   runtime_concretization_default  (copy spack.lock)
+##                                 \->   runtime_installation_default    (from buildcache)
+## builder_concretization_custom
+## builder_installation_custom      ->   runtime_concretization_custom   (copy spack.lock)
+##                                 \->   runtime_installation_custom     (from buildcache)
 ##
 
 
@@ -108,14 +103,14 @@ EOF
 
 
 ## ========================================================================================
-## runtime_default
-## - runtime base with installation of default versions (buildcache populated by builder)
+## runtime_concretization_default
+## - runtime base with concretization of default versions (taken from equivalent builder)
 ## ========================================================================================
-FROM ${DOCKER_REGISTRY}${RUNTIME_IMAGE}:${INTERNAL_TAG} AS runtime_default
+FROM ${DOCKER_REGISTRY}${RUNTIME_IMAGE}:${INTERNAL_TAG} AS runtime_concretization_default
 ARG TARGETPLATFORM
 
 # Open Container Initiative labels
-LABEL org.opencontainers.image.title="Electron-Ion Collider runtime image (default configuration, $TARGETPLATFORM)"
+LABEL org.opencontainers.image.title="Electron-Ion Collider runtime concretization image (default configuration, $TARGETPLATFORM)"
 
 ## Copy our default environment
 COPY --from=spack-environment . /opt/spack-environment/
@@ -128,6 +123,17 @@ ENV SPACK_COLOR="always"
 COPY --from=builder_installation_default \
   /opt/spack-environment/${ENV}/spack.* \
   /opt/spack-environment/${ENV}/
+
+
+## ========================================================================================
+## runtime_installation_default
+## - runtime base with installation of default versions (buildcache populated by builder)
+## ========================================================================================
+FROM runtime_concretization_default AS runtime_installation_default
+ARG TARGETPLATFORM
+
+# Open Container Initiative labels
+LABEL org.opencontainers.image.title="Electron-Ion Collider runtime installation image (default configuration, $TARGETPLATFORM)"
 
 # Installation (default environment, from buildcache)
 RUN --mount=type=cache,target=/var/cache/spack                          \
@@ -147,7 +153,7 @@ EOF
 ## builder_concretization_custom
 ## - builder base with concretization of custom versions
 ## ========================================================================================
-FROM builder_concretization_default AS builder_concretization_custom
+FROM builder_installation_default AS builder_concretization_custom
 ARG TARGETPLATFORM
 
 # Open Container Initiative labels
@@ -233,14 +239,14 @@ EOF
 
 
 ## ========================================================================================
-## runtime_custom
-## - runtime base with installation of custom versions (buildcache populated by builder)
+## runtime_concretization_custom
+## - runtime base with concretization of custom versions (taken from equivalent builder)
 ## ========================================================================================
-FROM runtime_default AS runtime_custom
+FROM runtime_installation_default AS runtime_concretization_custom
 ARG TARGETPLATFORM
 
 # Open Container Initiative labels
-LABEL org.opencontainers.image.title="Electron-Ion Collider runtime image (custom configuration, $TARGETPLATFORM)"
+LABEL org.opencontainers.image.title="Electron-Ion Collider runtime concretization image (custom configuration, $TARGETPLATFORM)"
 
 # Set spack environment directory
 ENV SPACK_ENV=/opt/spack-environment/${ENV}/epic
@@ -255,7 +261,18 @@ COPY --from=builder_installation_custom \
   /opt/spack-environment/packages.yaml \
   /opt/spack-environment/
 
-# Installation (custom environment, from buildcache)
+
+## ========================================================================================
+## runtime_installation_custom
+## - runtime base with installation of custom versions (buildcache populated by builder)
+## ========================================================================================
+FROM runtime_concretization_custom AS runtime_installation_custom
+ARG TARGETPLATFORM
+
+# Open Container Initiative labels
+LABEL org.opencontainers.image.title="Electron-Ion Collider runtime installation image (custom configuration, $TARGETPLATFORM)"
+
+# Installation (default environment, from buildcache)
 RUN --mount=type=cache,target=/var/cache/spack                          \
     --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
     <<EOF
@@ -267,13 +284,13 @@ EOF
 
 
 ## ========================================================================================
-## final image, based on runtime_custom
+## final image, based on runtime_installation_custom
 ## ========================================================================================
-FROM runtime_custom AS final
+FROM runtime_installation_custom AS final
 ARG TARGETPLATFORM
 
 # Open Container Initiative labels
-LABEL org.opencontainers.image.title="Electron-Ion Collider runtime image (custom configuration, $TARGETPLATFORM)"
+LABEL org.opencontainers.image.title="Electron-Ion Collider runtime installation image (custom configuration, $TARGETPLATFORM)"
 
 ## Ensure views directories, not symlinks
 RUN <<EOF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,30 +4,29 @@ The EIC container infrastructure uses a multi-stage build approach with separate
 
 ## Build Strategy
 
-The container build follows a three-track approach:
+The container build follows a two-track approach:
 
 ```mermaid
 flowchart TB
-    subgraph "Builder Concretization Track"
+    subgraph "Builder Track"
         A[builder_image<br/>debian_stable_base] --> B[builder_concretization_default<br/>Concretize spack environment]
-        B --> C[builder_concretization_custom<br/>Concretize custom versions]
-    end
-    
-    subgraph "Builder Installation Track"
-        B --> D[builder_installation_default<br/>Build packages]
-        C --> E[builder_installation_custom<br/>Build custom packages]
+        B --> C[builder_installation_default<br/>Build packages]
+        C --> D[builder_concretization_custom<br/>Concretize custom versions]
+        D --> E[builder_installation_custom<br/>Build custom packages]
     end
     
     subgraph "Runtime Track"
-        F[runtime_image<br/>debian_stable_base] --> G[runtime_default<br/>Copy spack.lock, install from buildcache]
-        G --> H[runtime_custom<br/>Copy custom spack.lock, install from buildcache]
-        H --> K[Final Image<br/>eic_ci / eic_xl]
+        F[runtime_image<br/>debian_stable_base] --> G[runtime_concretization_default<br/>Copy spack.lock from builder]
+        G --> H[runtime_installation_default<br/>Install from buildcache]
+        H --> I[runtime_concretization_custom<br/>Copy custom spack.lock]
+        I --> J[runtime_installation_custom<br/>Install custom from buildcache]
+        J --> K[Final Image<br/>eic_ci / eic_xl]
     end
     
-    D -.->|spack.lock| G
-    D -.->|buildcache| G
-    E -.->|spack.lock| H
-    E -.->|buildcache| H
+    C -.->|spack.lock| G
+    C -.->|buildcache| H
+    E -.->|spack.lock| I
+    E -.->|buildcache| J
 ```
 
 ## Multi-Architecture Support


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR reverts commit 4e49b9cfb96080030ae63ba97788f8ae6e47cfa1, #115.

The offending commit appears to cause the second stage concretization (custom) to do a complete rebuild of everything. That makes the entire image grow by a factor 2, which is not acceptable. E.g. https://github.com/eic/containers/actions/runs/20766901576/job/59634999346#step:15:11828 which should not have new package builds, but only build eicrecon etc.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.