### PR TITLE
feat: add alias for spack in z99_spack_lazy_load

### DIFF
--- a/containers/eic/profile.d/z99_spack_lazy_load
+++ b/containers/eic/profile.d/z99_spack_lazy_load
@@ -1,1 +1,0 @@
-alias spack='unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack'

--- a/containers/eic/profile.d/z99_spack_lazy_load
+++ b/containers/eic/profile.d/z99_spack_lazy_load
@@ -1,0 +1,1 @@
+alias spack='unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack'

--- a/containers/eic/profile.d/z99_spack_lazy_load.sh
+++ b/containers/eic/profile.d/z99_spack_lazy_load.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Create alias for first invocation of spack
+# that loads environment to avoid slow loads
+# wben sourcing environment by default
+alias spack='unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR adds an alias `alias spack='unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack'` to ensure that spack has the right environment when invoked.
