### PR TITLE
Revert "feat: add alias for spack in z99_spack_lazy_load (#130)"

### DIFF
--- a/containers/eic/profile.d/z99_spack_lazy_load.sh
+++ b/containers/eic/profile.d/z99_spack_lazy_load.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Create alias for first invocation of spack
-# that loads environment to avoid slow loads
-# wben sourcing environment by default
-alias spack='unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This reverts commit 201ca937da06d88a32f28d727b2f98d900c33be9. It fails with
```
$ LD_LIBRARY_PATH="" eic-shell 
INFO:    Environment variable SINGULARITY_BINDPATH is set, but APPTAINER_BINDPATH is preferred
alias: could not parse "unalias spack && source ${SPACK_ROOT}/share/spack/setup-env.sh && spack": 1:15: && is not a valid word
```

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
