### PR TITLE
Revert "feat: jana2 2026.01.01 (#122)"

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="640379e054350a37f3336b5239f8661398ebb825"
+EICSPACK_VERSION="6fcf84983bfb9fc3d63e9540915001ef03ff5dbf"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This reverts commit a9a8bfe97dd8414dfffc154c9701047ff381fd8f.

The upgrade to JANA2 2026.01.01 is causing significant CI regressions as demonstrated in two consecutive scheduled main branch CI runs:
- https://github.com/eic/EICrecon/actions/runs/21015227008/job/60419158382#step:7:197 (jana2 2.4.3)
- https://github.com/eic/EICrecon/actions/runs/21038397824/job/60494414864#step:7:201 (jana2 2026.01.01)

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __
