### PR TITLE
chore: edm4eic-8.6.0

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="6fcf84983bfb9fc3d63e9540915001ef03ff5dbf"
+EICSPACK_VERSION="b63d5612c41b29c1a65b5607b544f1766c323bf4"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -122,7 +122,7 @@ packages:
     - '@656aa3192b097a631ddd1e0380e80c26fd6644a7'
   edm4eic:
     require:
-    - '@8.5.0' # EDM4EIC_VERSION
+    - '@8.6.0' # EDM4EIC_VERSION
     - cxxstd=20
   edm4hep:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR updated EDM4eic to 8.6.0.