### PR TITLE
chore: irt-1.0.9

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="8e231cc01baa7b4cdc285671e5fa4e92d2d35547"
+EICSPACK_VERSION="0697076ae087863cf87e48acfc1457fa40fda478"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -233,7 +233,7 @@ packages:
     - '@7.1.1-11:'
   irt:
     require:
-    - '@1.0.8'
+    - '@1.0.9'
   irt2:
     require:
     - '@2.1.0'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] https://github.com/eic/eic-spack/pull/817

This PR upgrades `irt` to 1.0.9.