### PR TITLE
fix(ci): explicitly required edm4eic cxxstd=20 in user_spack_environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -513,7 +513,7 @@ user_spack_environment:
   script:
     - source /opt/spack/share/spack/setup-env.sh
     - spack env activate --create edm4eic
-    - spack add edm4eic@git.main
+    - spack add edm4eic@git.main cxxstd=20
     - spack concretize 
     - spack install --only dependencies edm4eic
     - ls -al /opt/software/linux-*/compiler-wrapper-1.0-*/libexec/spack/gcc/g++


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that for edm4eic@main (until the next release, when we can update the default) we use the required cxxstd=20. Addresses https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7166992#L506.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7166992#L506)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __