### PR TITLE
chore: edm4eic-8.7.0

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="4659531f7f021f148110a5bcf6b638d36fa88d33"
+EICSPACK_VERSION="36a4e51ace5f74d4dc06033bc1f573350a91a2b2"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -125,7 +125,7 @@ packages:
     - '@656aa3192b097a631ddd1e0380e80c26fd6644a7'
   edm4eic:
     require:
-    - '@8.6.0' # EDM4EIC_VERSION
+    - '@8.7.0' # EDM4EIC_VERSION
     - cxxstd=20
   edm4hep:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades EDM4eic to 8.7.0.