### PR TITLE
chore: eic-smear-1.1.16

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="36a4e51ace5f74d4dc06033bc1f573350a91a2b2"
+EICSPACK_VERSION="9f7ef015437f210c46122a3ff4de438cc35e3202"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -138,7 +138,7 @@ packages:
       prefix: /usr
   eic-smear:
     require:
-    - '@1.1.15'
+    - '@1.1.16'
   eicrecon:
     require:
     - '@1.33.1' # EICRECON_VERSION


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades `eic-smear` to v1.1.16.