### PR TITLE
chore: dd4hep-1.35 (rntuple support)

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -111,7 +111,7 @@ packages:
     - '@1.16.2:'
   dd4hep:
     require:
-    - '@1.34'
+    - '@1.35'
     - +ddg4 +ddcad +edm4hep +hepmc3 +xercesc
     - any_of: [+ddeve +utilityapps, -ddeve -utilityapps] # FIXME ^root +x +opengl when +utilityapps
   doxygen:

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -44,6 +44,7 @@ cfa8d650480c409de2d568cf1355bf7e509f4c1c
 50433a4a02370e9035b85820cd438a64d5433749
 9686af7a77fb96d177a825c9ea2343ed15512d75
 6eeb0dd820467e5542d41d6784ee86de8f84d4a0
+688d5e5e20fa9aa2647026143205c8aaa0625590
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -88,3 +89,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 50433a4a02370e9035b85820cd438a64d5433749: python ecosystem: bulk update
 ## 9686af7a77fb96d177a825c9ea2343ed15512d75: snakemake: add v9 versions and dependencies
 ## 6eeb0dd820467e5542d41d6784ee86de8f84d4a0: py-snakemake-storage-plugin-fs: add v1.1.3
+## 688d5e5e20fa9aa2647026143205c8aaa0625590: dd4hep: add v1.35


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] #140 

This PR upgrades DD4hep to 1.35.