### PR TITLE
hotfix: extend llvm sha-1 deadline by a month

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -109,9 +109,9 @@ esac
 # Clang repository
 curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 if [ ${VERSION_CODENAME} = forky ] ; then
-  echo "deb [signed_by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
+  echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 else
-  echo "deb [signed_by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list
+  echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 fi
 # Install packages
 apt-get -yqq update

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -74,6 +74,13 @@ apt-get -yqq autoremove
 localedef -i en_US -f UTF-8 en_US.UTF-8
 EOF
 
+# Override SHA-1 second pre-image resistance deadline
+## FIXME Remove when LLVM has fixed their signature
+COPY /etc/crypto-policies/back-ends/sequoia.config << EOF
+[hash_algorithms]
+sha1 = 2026-03-01
+EOF
+
 # Install updated compilers, with support for multiple base images
 ## Ubuntu: latest gcc from toolchain ppa, latest stable clang
 ## Debian: default gcc with distribution, latest stable clang

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -76,7 +76,7 @@ EOF
 
 # Override SHA-1 second pre-image resistance deadline
 ## FIXME Remove when LLVM has fixed their signature
-COPY /etc/crypto-policies/back-ends/sequoia.config <<EOF
+COPY <<EOF /etc/crypto-policies/back-ends/sequoia.config
 [hash_algorithms]
 sha1 = 2026-03-01
 EOF

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -76,7 +76,7 @@ EOF
 
 # Override SHA-1 second pre-image resistance deadline
 ## FIXME Remove when LLVM has fixed their signature
-COPY /etc/crypto-policies/back-ends/sequoia.config << EOF
+COPY /etc/crypto-policies/back-ends/sequoia.config <<EOF
 [hash_algorithms]
 sha1 = 2026-03-01
 EOF

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -109,9 +109,9 @@ esac
 # Clang repository
 curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 if [ ${VERSION_CODENAME} = forky ] ; then
-  echo "deb http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
+  echo "deb [signed_by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 else
-  echo "deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list
+  echo "deb [signed_by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 fi
 # Install packages
 apt-get -yqq update

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -108,7 +108,7 @@ case ${ID} in
 esac
 # Clang repository
 curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-if [ ${VERSION_CODENAME} = trixie ] ; then
+if [ ${VERSION_CODENAME} = forky ] ; then
   echo "deb http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 else
   echo "deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -108,7 +108,7 @@ case ${ID} in
 esac
 # Clang repository
 curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-if [ ${VERSION_CODENAME} = forky ] ; then
+if [ ${VERSION_CODENAME} = trixie ] ; then
   echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/unstable llvm-toolchain${CLANG} main" > /etc/apt/sources.list.d/llvm.list
 else
   echo "deb [signed-by=/etc/apt/trusted.gpg.d/apt.llvm.org.asc] http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME}${CLANG} main" > /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR extends the SHA-1 second pre-image resistance deadline by 1 month. Tracking https://github.com/llvm/llvm-project/issues/179147.