### PR TITLE
feat: add eic-opticks to eic_cuda

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="f07e969995563a11ca81138b4489b090c08ac71a"
+EICSPACK_VERSION="64086c55652c0b0963372dd0902bc4d41982956c" # FIXME once eic-spack merged

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="ac428a2d42304ec8a1fca615235c388684b5983d" # FIXME once eic-spack merged
+EICSPACK_VERSION="447191c7866530e683f6fdfe3690a108af57e88c" # FIXME once eic-spack merged

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="64086c55652c0b0963372dd0902bc4d41982956c" # FIXME once eic-spack merged
+EICSPACK_VERSION="ac428a2d42304ec8a1fca615235c388684b5983d" # FIXME once eic-spack merged

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -25,6 +25,7 @@ spack:
   - dpmjet
   - east
   - edm4hep
+  - eic-opticks
   - eic-smear
   - eigen
   - emacs

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -139,6 +139,7 @@ packages:
   eic-opticks:
     require:
     - '@7057d7bd7f755253c416b813e59f0af28de98ddc'
+    - '%clang'
   eic-smear:
     require:
     - '@1.1.16'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -138,8 +138,7 @@ packages:
       prefix: /usr
   eic-opticks:
     require:
-    - '@7057d7bd7f755253c416b813e59f0af28de98ddc'
-    - '%clang'
+    - '@073ac31a83f9a5651b99a737b30da18117de74d5'
   eic-smear:
     require:
     - '@1.1.16'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -136,6 +136,9 @@ packages:
     externals:
     - spec: egl@1.5.0
       prefix: /usr
+  eic-opticks:
+    require:
+    - '@7057d7bd7f755253c416b813e59f0af28de98ddc'
   eic-smear:
     require:
     - '@1.1.16'


### PR DESCRIPTION
This uses https://github.com/eic/eic-spack/pull/824 to provide an opticks installation for eic-shell.