### PR TITLE
chore: clang-20 on trixie (non-cuda)

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -96,7 +96,8 @@ case ${ID} in
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
-    apt-get install -yqq software-properties-common
+    apt-get -yqq update
+    apt-get -yqq install software-properties-common
     add-apt-repository ppa:ubuntu-toolchain-r/ppa
     case ${VERSION_CODENAME} in
       noble) GCC="-13" ; CLANG="-17" ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -96,7 +96,7 @@ case ${ID} in
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
-    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/ubuntu-toolchain.list
+    add-apt-repository ppa:ubuntu-toolchain-r/ppa
     case ${VERSION_CODENAME} in
       noble) GCC="-13" ; CLANG="-17" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -96,7 +96,7 @@ case ${ID} in
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
-    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu/${VERSION_CODENAME} main" > /etc/apt/source.list.d/ubuntu-toolchain.list
+    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu/${VERSION_CODENAME} main" > /etc/apt/sources.list.d/ubuntu-toolchain.list
     case ${VERSION_CODENAME} in
       noble) GCC="-13" ; CLANG="-17" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -65,6 +65,7 @@ apt-get -yqq install --no-install-recommends                            \
         openssh-client                                                  \
         parallel                                                        \
         patch                                                           \
+        software-properties-common                                      \
         time                                                            \
         unzip                                                           \
         vim-nox                                                         \

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -96,7 +96,7 @@ case ${ID} in
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
-    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu/${VERSION_CODENAME} main" > /etc/apt/sources.list.d/ubuntu-toolchain.list
+    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/ubuntu-toolchain.list
     case ${VERSION_CODENAME} in
       noble) GCC="-13" ; CLANG="-17" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -87,7 +87,7 @@ EOF
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked <<EOF
 . /etc/os-release
-mkdir -p /etc/apt/source.list.d
+mkdir -p /etc/apt/sources.list.d
 # GCC and CLANG version and repository
 case ${ID} in
   debian)

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -65,7 +65,6 @@ apt-get -yqq install --no-install-recommends                            \
         openssh-client                                                  \
         parallel                                                        \
         patch                                                           \
-        software-properties-common                                      \
         time                                                            \
         unzip                                                           \
         vim-nox                                                         \
@@ -97,6 +96,7 @@ case ${ID} in
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
+    apt-get install -yqq software-properties-common
     add-apt-repository ppa:ubuntu-toolchain-r/ppa
     case ${VERSION_CODENAME} in
       noble) GCC="-13" ; CLANG="-17" ;;

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -92,15 +92,12 @@ mkdir -p /etc/apt/source.list.d
 case ${ID} in
   debian)
     case ${VERSION_CODENAME} in
-      bookworm) GCC="-12" ; CLANG="-18" ;;
-      trixie) GCC="-14" ; CLANG="-19" ;;
+      trixie) GCC="-14" ; CLANG="-20" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;
   ubuntu)
     echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/ppa/ubuntu/${VERSION_CODENAME} main" > /etc/apt/source.list.d/ubuntu-toolchain.list
     case ${VERSION_CODENAME} in
-      focal) GCC="-10" ; CLANG="-16" ;;
-      jammy) GCC="-12" ; CLANG="-16" ;;
       noble) GCC="-13" ; CLANG="-17" ;;
       *) echo "Unsupported VERSION_CODENAME=${VERSION_CODENAME}" ; exit 1 ;;
     esac ;;

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -242,7 +242,7 @@ packages:
     - '@2.1.0'
   iwyu:
     require:
-    - '@0.23'
+    - '@0.23:'
   jana2:
     require:
     - '@2.4.3'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades the clang version used in the trixie-based stacks to v20. Also removes untested legacy base images (bookworm, focal, jammy).