### PR TITLE
fix: run spack buildcache update-index

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -96,6 +96,7 @@ export CCACHE_DIR=/ccache
 mkdir -p /var/cache/spack/blobs/sha256/
 find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +7 -delete
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
+spack buildcache update-index
 spack clean --downloads --stage
 ccache --show-stats
 ccache --zero-stats
@@ -231,6 +232,7 @@ RUN --mount=type=cache,target=/ccache,id=ccache-${TARGETPLATFORM}              \
 set -e
 export CCACHE_DIR=/ccache
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
+spack buildcache update-index
 spack clean --downloads --stage
 spack gc --yes-to-all go go-bootstrap rust rust-bootstrap py-setuptools-rust py-maturin
 ccache --show-stats

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -96,7 +96,11 @@ export CCACHE_DIR=/ccache
 mkdir -p /var/cache/spack/blobs/sha256/
 find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +7 -delete
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
-spack buildcache update-index
+for mirror in eicweb ghcr ; do
+  if spack mirror list | grep -qw "^${mirror}" ; then
+    spack buildcache update-index ${mirror}
+  fi
+done
 spack clean --downloads --stage
 ccache --show-stats
 ccache --zero-stats
@@ -232,7 +236,11 @@ RUN --mount=type=cache,target=/ccache,id=ccache-${TARGETPLATFORM}              \
 set -e
 export CCACHE_DIR=/ccache
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
-spack buildcache update-index
+for mirror in eicweb ghcr ; do
+  if spack mirror list | grep -qw "^${mirror}" ; then
+    spack buildcache update-index ${mirror}
+  fi
+done
 spack clean --downloads --stage
 spack gc --yes-to-all go go-bootstrap rust rust-bootstrap py-setuptools-rust py-maturin
 ccache --show-stats


### PR DESCRIPTION
### Briefly, what does this PR introduce?
A warning reported in #151 is:
```
==> Warning: The following issues were ignored while updating the indices of binary caches
  Multiple errors during fetching:
        Error 1: FetchIndexError: Could not fetch manifest from https://ghcr.io/v2/eic/spack-v2025.11.0/manifests/index.spack, due to: GET https://ghcr.io/v2/eic/spack-v2025.11.0/manifests/index.spack returned 404: Not Found
        Error 2: FetchIndexError: Could not fetch manifest from https://ghcr.io/v2/eic/spack-v2025.11.0/manifests/index.spack, due to: GET https://ghcr.io/v2/eic/spack-v2025.11.0/manifests/index.spack returned 404: Not Found
```
This appears to be caused by not running the buildcache update-index after writing buildcache entries. This PR adds an explicit buildcache update-index step.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: warning in #151)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.