### PR TITLE
mirror.yaml: run on pull_request

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        ref: ${{ github.head_ref }}
     - name: Push to EICweb
       uses: eic/gitlab-sync@master
       with:


### PR DESCRIPTION
This is needed to restore passing of GITHUB_PR.

Resolves: #132 