### PR TITLE
chore: acts-45.1.1

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -28,7 +28,7 @@ packages:
     - any_of: [build_type=Release, '@:']
   acts:
     require:
-    - '@45.0.0'
+    - '@45.1.1'
     - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +tgeo +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -45,6 +45,8 @@ cfa8d650480c409de2d568cf1355bf7e509f4c1c
 9686af7a77fb96d177a825c9ea2343ed15512d75
 6eeb0dd820467e5542d41d6784ee86de8f84d4a0
 090c7437cff0352a9d69b9b9c6c9f60a4600862f
+58597d3567384cb7be500b336c5c4edabb343be7
+4b77ca9bd1e6e828ea2c6027bca817cb82d8ac61
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -90,3 +92,5 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 9686af7a77fb96d177a825c9ea2343ed15512d75: snakemake: add v9 versions and dependencies
 ## 6eeb0dd820467e5542d41d6784ee86de8f84d4a0: py-snakemake-storage-plugin-fs: add v1.1.3
 ## 090c7437cff0352a9d69b9b9c6c9f60a4600862f: acts: add v45.0.0
+## 58597d3567384cb7be500b336c5c4edabb343be7: acts: add v45.1.0 and v45.1.1
+## 4b77ca9bd1e6e828ea2c6027bca817cb82d8ac61: acts: improve variant dependency handling


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] https://github.com/acts-project/acts/pull/5042 or upgrade to v45.1.0 or later

This PR upgrades Acts to v45.1.1.