### PR TITLE
fix: eic-spack: py-uproot: backport RNTuple v1.0.1.0 format support

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="3ac992dd4ce49164780d1496c23d837bd58290d1"
+EICSPACK_VERSION="26229254caba2ce95a5ce3741d33ee59aa252633"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="affdd6e301d40d1bb5dcb48c7f1e6ae196c4f243"
+EICSPACK_VERSION="3ac992dd4ce49164780d1496c23d837bd58290d1"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR backports RNTuple v1.0.1.0 support to the older uproot version in the container.