### PR TITLE
chore: acts 45.1.1

### DIFF
--- a/key4hep-spack.sh
+++ b/key4hep-spack.sh
@@ -5,4 +5,4 @@ KEY4HEPSPACK_ORGREPO="key4hep/key4hep-spack"
 
 ## Key4HEP spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-KEY4HEPSPACK_VERSION="9a65e824449f204cf083c29053401cbb60ad39d4"
+KEY4HEPSPACK_VERSION="c53548c3ee19cac56017c5d096aaf5b015d0e5a6"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -36,7 +36,7 @@ packages:
   acts:
     require:
     - '@45.1.1'
-    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +tgeo +pr4496 +pr4502 +pr4620
+    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +root +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'
       when: '^dd4hep %gcc'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -35,7 +35,7 @@ packages:
     - cxxstd=17
   acts:
     require:
-    - '@45.0.0'
+    - '@45.1.1'
     - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +tgeo +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -35,7 +35,7 @@ packages:
     - cxxstd=17
   acts:
     require:
-    - '@44.4.0'
+    - '@45.0.0'
     - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +tgeo +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Needs:
- [x] #174 
- [x] #149 
- [x] https://github.com/eic/eic-spack/pull/838
- [x] https://github.com/key4hep/key4hep-spack/pull/861

This PR update `acts` to v45.1.1. Follows #166 with correct branch name. Juggler gets a minor upgrade to make sure it can handle the updated interfaces in Acts v45.
