### PR TITLE
chore: spack-1.0.3

### DIFF
--- a/spack.sh
+++ b/spack.sh
@@ -9,6 +9,7 @@ SPACK_VERSION="v1.0.3"
 read -r -d '' SPACK_CHERRYPICKS <<- \
 --- || true
 09f75ee426a2e05e0543570821582480ff823ba5
+a462612b64e97fa7dfe461c32c58553fd6ec63c5
 292b0dcaba3b2a5e3f9668d205d39fee2c715721
 ---
 ## Optional hash table with comma-separated file list
@@ -18,4 +19,5 @@ read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
 ## Ref: https://github.com/spack/spack/commit/[hash]
 ## [hash]: [description]
 ## 09f75ee426a2e05e0543570821582480ff823ba5: setup-env.sh: if exe contains qemu, use /proc/$$/comm instead
+## a462612b64e97fa7dfe461c32c58553fd6ec63c5: fix: allow versions with git attr in packages without git attr
 ## 292b0dcaba3b2a5e3f9668d205d39fee2c715721: fix: write created time field with OCI buildcache config

--- a/spack.sh
+++ b/spack.sh
@@ -3,7 +3,7 @@ SPACK_ORGREPO="spack/spack"
 
 ## Spack github version, e.g. v0.18.1 or commit hash
 ## note: nightly builds will use e.g. releases/v1.0
-SPACK_VERSION="v1.0.2"
+SPACK_VERSION="v1.0.3"
 
 ## Space-separated list of spack cherry-picks
 read -r -d '' SPACK_CHERRYPICKS <<- \

--- a/spack.sh
+++ b/spack.sh
@@ -9,7 +9,6 @@ SPACK_VERSION="v1.0.3"
 read -r -d '' SPACK_CHERRYPICKS <<- \
 --- || true
 09f75ee426a2e05e0543570821582480ff823ba5
-a462612b64e97fa7dfe461c32c58553fd6ec63c5
 292b0dcaba3b2a5e3f9668d205d39fee2c715721
 ---
 ## Optional hash table with comma-separated file list
@@ -19,5 +18,4 @@ read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
 ## Ref: https://github.com/spack/spack/commit/[hash]
 ## [hash]: [description]
 ## 09f75ee426a2e05e0543570821582480ff823ba5: setup-env.sh: if exe contains qemu, use /proc/$$/comm instead
-## a462612b64e97fa7dfe461c32c58553fd6ec63c5: fix: allow versions with git attr in packages without git attr
 ## 292b0dcaba3b2a5e3f9668d205d39fee2c715721: fix: write created time field with OCI buildcache config


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades spack to v1.0.3, https://github.com/spack/spack/releases/tag/v1.0.3.