### PR TITLE
chore: eic-spack: convert repository to spack packages API v2 repo layout

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -333,5 +333,5 @@ RUN <<EOF
 set -e
 git clone --filter=tree:0 https://github.com/${EICSPACK_ORGREPO}.git ${EICSPACK_ROOT}
 git -C ${EICSPACK_ROOT} checkout ${EICSPACK_SHA:-${EICSPACK_VERSION}}
-spack repo add --scope site "${EICSPACK_ROOT}"
+spack repo add --scope site "${EICSPACK_ROOT}/spack_repo/eic"
 EOF

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="26229254caba2ce95a5ce3741d33ee59aa252633"
+EICSPACK_VERSION="42be3da82b02e63350418707b89e881e83c671bc"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades eic-spack to the spack packages API v2.0.