### PR TITLE
chore: spack-v1.0.4

### DIFF
--- a/spack.sh
+++ b/spack.sh
@@ -3,7 +3,7 @@ SPACK_ORGREPO="spack/spack"
 
 ## Spack github version, e.g. v0.18.1 or commit hash
 ## note: nightly builds will use e.g. releases/v1.0
-SPACK_VERSION="v1.0.3"
+SPACK_VERSION="v1.0.4"
 
 ## Space-separated list of spack cherry-picks
 read -r -d '' SPACK_CHERRYPICKS <<- \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Spack v1.0.3 was yanked due to incorrect tagging, but it was only yanked after it was briefly retagged correctly and got merged into our master branch. Spack v1.0.4 is identical to what is in our master branch and there should be no changes at all due to this PR.