### PR TITLE
feat: irt2 2.1.3

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="42be3da82b02e63350418707b89e881e83c671bc"
+EICSPACK_VERSION="2a0b2e4002346624c8b2504a714be9ae4898e5ae"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -242,7 +242,7 @@ packages:
     - '@1.0.10'
   irt2:
     require:
-    - '@2.1.2'
+    - '@2.1.3'
   iwyu:
     require:
     - '@0.23:'


### PR DESCRIPTION
This should re-enable compilation of epic against irt2.