### PR TITLE
chore: py-epic-capybara: add rntuple support

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -401,7 +401,7 @@ packages:
     - '@2025.2.0:'
   py-epic-capybara:
     require:
-    - '@git.ef2a8790312b9b697655b28a07b353e601bfa3b8'
+    - '@git.8ba297605f5d3419244643c3332364196552789e'
   py-flatbuffers:
     require:
     - '@25.9.23:'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades `py-epic-capybara` to add rntuple support.