### PR TITLE
fix: eic-spack: py-uproot: Add patch for uproot RNTuple _from_zigzag unsigned integer fix

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="c6c0b369542bf60e79f684fb4a37f8c766dff230"
+EICSPACK_VERSION="cd0487fbc78717c298c1efe2b8fa7026366ffcc6"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR applies a bugfix to py-uproot.