### PR TITLE
feat: rucio +argcomplete

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -497,6 +497,7 @@ packages:
   py-rucio-clients:
     require:
     - '@37.3.0:'
+    - +argcomplete
   py-scipy:
     require:
     - '@1.14.1:'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR ensures that Rucio client autocompletion is installed, https://rucio.cern.ch/documentation/user/using_the_client#enable-command-line-autocompletion (probably requires some other environment loading to ensure the `eval "$(register-python-argcomplete rucio)"` is executed in a scalable way).
