### PR TITLE
chore: spack-1.1.1

### DIFF
--- a/docs/spack-environment.md
+++ b/docs/spack-environment.md
@@ -151,7 +151,7 @@ is shown here. Refer to `spack.sh` and `spack-packages.sh` for the current lists
 
 ```bash
 # From spack.sh (illustrative — see spack.sh for actual commits)
-SPACK_VERSION="v1.1.0"
+SPACK_VERSION="v1.1.1"
 SPACK_CHERRYPICKS=$(cat <<- EOF
 09f75ee426a2e05e0543570821582480ff823ba5
 a462612b64e97fa7dfe461c32c58553fd6ec63c5

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -280,7 +280,7 @@ packages:
     - '@15.1.0' # JUGGLER_VERSION
   julia:
     require:
-    - '@1.11'
+    - '@1.12'
   just:
     require:
     - '@1.46.0'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -109,6 +109,9 @@ packages:
   cppcoro:
     require:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
+  curl:
+    require:
+    - tls=openssl
   dawn:
     require:
     - '@3_91a'

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -29,6 +29,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
 b11529d6bbd8abc9f7bde6faf290b1c22385a022
+9d1b52d36a4c89d9c3964f599cd00232b901e9ac
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -55,3 +56,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
 ## b11529d6bbd8abc9f7bde6faf290b1c22385a022: py-onnxruntime: only run tests when self.run_tests
+## 9d1b52d36a4c89d9c3964f599cd00232b901e9ac: julia: avoid cascading mbedtls in v1.12+

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -28,6 +28,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
+b11529d6bbd8abc9f7bde6faf290b1c22385a022
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -53,3 +54,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
+## b11529d6bbd8abc9f7bde6faf290b1c22385a022: py-onnxruntime: only run tests when self.run_tests

--- a/spack.sh
+++ b/spack.sh
@@ -5,7 +5,7 @@ SPACK_ORGREPO="spack/spack"
 
 ## Spack github version, e.g. v0.18.1 or commit hash
 ## note: nightly builds will use e.g. releases/v1.0
-SPACK_VERSION="v1.1.0"
+SPACK_VERSION="v1.1.1"
 
 ## Space-separated list of spack cherry-picks
 read -r -d '' SPACK_CHERRYPICKS <<- \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades spack to [v1.1.1](https://github.com/spack/spack/releases/tag/v1.1.1), [diff](https://github.com/spack/spack/compare/v1.1.0...v1.1.1).

In spack v1.1.1, the silent ignoring of libcurl SSL certificate errors in CMake FetchContent operations was fixed and is now an error. In the container build, we are running without access to the CA certificates that sign the re-encrypted MITM SSL pages on US DOE nodes. Thus, this minor bugfix upgrade requires quite a bit more care than is typical.