### PR TITLE
fix: build root without +vc

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -545,7 +545,7 @@ packages:
   root:
     require:
     - '@6.38.00'
-    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +vc +x +xrootd +ssl
+    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
   sherpa:
     require:


### PR DESCRIPTION
We are unlikely to use this and it's going away upstream.

Addresses Vc.pcm issue mentioned in https://github.com/eic/containers/issues/181#issuecomment-4000252345