### PR TITLE
feat: patch py-uproot, hepmcmerger 2.2.0, juggler 15.1.0

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="c6c0b369542bf60e79f684fb4a37f8c766dff230"
+EICSPACK_VERSION="3d29d1a016eb09ca0e695ab994fd4d7ccd5d4c71"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -234,7 +234,7 @@ packages:
     - +python +rootio
   hepmcmerger:
     require:
-    - '@2.1.0'
+    - '@2.2.0'
   heppdt:
     require:
     - '@2.06.01'
@@ -260,7 +260,7 @@ packages:
     - -ipo +podio +root +zmq
   juggler:
     require:
-    - '@15.0.5' # JUGGLER_VERSION
+    - '@15.1.0' # JUGGLER_VERSION
     - cxxstd=20
   julia:
     require:


### PR DESCRIPTION
Downstream changes:
- https://github.com/eic/eic-spack/commit/f02055947f360b5067f8e9fc0f4e83334452627f
- https://github.com/eic/eic-spack/commit/cd0487fbc78717c298c1efe2b8fa7026366ffcc6
- https://github.com/eic/eic-spack/commit/3d29d1a016eb09ca0e695ab994fd4d7ccd5d4c71