### PR TITLE
chore: py-epic-capybara: perf: reduce .json.gz file sizes

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -405,7 +405,7 @@ packages:
     - '@2025.2.0:'
   py-epic-capybara:
     require:
-    - '@git.8ba297605f5d3419244643c3332364196552789e'
+    - '@git.9e72c8425829d981d06b30363eb0274ce867518d'
   py-flatbuffers:
     require:
     - '@25.9.23:'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades py-epic-capybara with https://github.com/eic/epic-capybara/pull/28, https://github.com/eic/epic-capybara/pull/29, https://github.com/eic/epic-capybara/pull/31, all of which reduce the size of the output json.gz files.
