### PR TITLE
eic-opticks: revert back to 073

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -146,7 +146,7 @@ packages:
       prefix: /usr
   eic-opticks:
     require:
-    - '@0.1.0'
+    - '@073ac31a83f9a5651b99a737b30da18117de74d5'
   eic-smear:
     require:
     - '@1.1.16'


### PR DESCRIPTION
Original PR did break the eic_cuda container build, we need to revert.