### PR TITLE
feat: only link roots into default view

### DIFF
--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -74,4 +74,5 @@ spack:
   - root
   - snakemake
   - spdlog
+  - vdt  # ensure headers in view for ROOT
   - xrootd

--- a/spack-environment/tf/spack.yaml
+++ b/spack-environment/tf/spack.yaml
@@ -47,4 +47,5 @@ spack:
   - py-toml
   - py-uproot
   - py-vector
+  - root
   - xrootd

--- a/spack-environment/view.yaml
+++ b/spack-environment/view.yaml
@@ -3,7 +3,6 @@ view:
     root: /opt/local
     exclude:
       - epic
-      - py-pip@23.0
       - py-urllib3@1
     link: roots
     link_type: symlink

--- a/spack-environment/view.yaml
+++ b/spack-environment/view.yaml
@@ -3,6 +3,9 @@ view:
     root: /opt/local
     exclude:
       - epic
+      - py-pip@23.0
+      - py-urllib3@1
+    link: roots
     link_type: symlink
   detectors:
     root: /opt/detector

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -131,5 +131,6 @@ spack:
   - stow
   - strace
   - valgrind
+  - vdt  # ensure headers in view for ROOT
   - xrootd
   - xeyes


### PR DESCRIPTION
### Briefly, what does this PR introduce?
We keep hearing about many files from OSG folks. We have a symlink for all packages, even if we don't actually need to expose some of this functionality beyond explicitly included packages. This restricts what is linked into the view to only the roots.

I think we've tried this before. I forget why it failed. We'll see...