### PR TITLE
chore: eic-spack: remove acts identification variant

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="ad647bfa37005fade497aae878273933d9939a9e"
+EICSPACK_VERSION="6cc06cacad0e7a6d802c67743d80257c01af664e"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="d6fcdbcb745343781275541671cc5a254068e3e5"
+EICSPACK_VERSION="ad647bfa37005fade497aae878273933d9939a9e"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -261,7 +261,6 @@ packages:
   juggler:
     require:
     - '@15.1.0' # JUGGLER_VERSION
-    - cxxstd=20
   julia:
     require:
     - '@1.11'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR upgrades eic-spack to avoid any reference to the defunct acts identification variant.

Fixes: https://github.com/eic/containers/actions/runs/23917302649/job/69755087022?pr=219#step:15:4335