### PR TITLE
fix: remove obsolete packages from default view exclude list

### DIFF
--- a/spack-environment/view.yaml
+++ b/spack-environment/view.yaml
@@ -3,8 +3,6 @@ view:
     root: /opt/local
     exclude: 
     - epic
-    - py-pip@23.0
-    - py-urllib3@1
     link_type: symlink
   detectors:
     root: /opt/detector


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR removes py-pip and py-urllib3 from the default exclude list. Due to upgrades to the `package.yaml` requirements, no versions can ever match this.