### PR TITLE
fix: unclang py-tensorflow and weekly bust base layer cache

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -417,13 +417,13 @@ jobs:
         - BUILD_IMAGE: eic_
           BUILD_TYPE: default
           BUILDER_IMAGE: cuda_devel
-          RUNTIME_IMAGE: cuda_devel
+          RUNTIME_IMAGE: cuda_runtime
           ENV: tf
           arch: amd64
           runner: ubuntu-latest
           PLATFORM: linux/amd64
           target: final
-          SPACK_DUPLICATE_ALLOWLIST: "epic|llvm|py-setuptools|py-urllib3"
+          SPACK_DUPLICATE_ALLOWLIST: "epic|llvm|py-setuptools|py-urllib3|py-dask|py-dask-awkward|py-dask-histogram|py-distributed|py-requests"
       fail-fast: false
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -68,12 +68,14 @@ jobs:
     outputs:
       CUDA_VERSION: ${{ steps.env.outputs.CUDA_VERSION }}
       CUDA_OS: ${{ steps.env.outputs.CUDA_OS }}
+      BUILDWEEK: ${{ steps.env.outputs.BUILDWEEK }}
     steps:
       - name: Turn env into outputs
         id: env
         run: |
           echo "CUDA_VERSION=${{ env.CUDA_VERSION }}" >> $GITHUB_OUTPUT
           echo "CUDA_OS=${{ env.CUDA_OS }}" >> $GITHUB_OUTPUT
+          echo "BUILDWEEK=$(date +%Yw%V)" >> $GITHUB_OUTPUT
 
   base:
     name: Build ${{ matrix.BUILD_IMAGE }} on ${{ matrix.arch }}
@@ -163,8 +165,9 @@ jobs:
         id: cache-base-mounts
         with:
           path: cache-mount-base-${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}
-          key: ${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}-base-mounts-${{ github.ref_name }}
+          key: ${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}-base-mounts-${{ github.ref_name }}-${{ needs.env.outputs.BUILDWEEK }}
           restore-keys: |
+            ${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}-base-mounts-main-${{ needs.env.outputs.BUILDWEEK }}
             ${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}-base-mounts-main
             ${{ matrix.BUILD_IMAGE }}-${{ matrix.arch }}-base-mounts-
       - name: Inject cache mounts into builder
@@ -223,6 +226,7 @@ jobs:
             EICSPACK_VERSION=${{ steps.eic-spack.outputs.version }}
             EICSPACK_SHA=${{ steps.eic-spack.outputs.sha }}
             jobs=${{ env.JOBS }}
+            BUILDWEEK=${{ needs.env.outputs.BUILDWEEK }}
           cache-from: |
             type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_REF_POINT_SLUG }}-${{ matrix.arch }}
             type=registry,ref=${{ env.GH_REGISTRY }}/${{ env.GH_REGISTRY_USER }}/buildcache:${{ matrix.BUILD_IMAGE }}-${{ env.GITHUB_BASE_REF_SLUG }}-${{ matrix.arch }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -345,6 +345,7 @@ base:
                    --build-arg EICSPACK_VERSION=${EICSPACK_VERSION}
                    --build-arg EICSPACK_SHA=$(sh .ci/resolve_git_ref "${EICSPACK_ORGREPO}" "${EICSPACK_VERSION}")
                    --build-arg jobs=${JOBS}
+                   --build-arg BUILDWEEK=$(date +%Yw%V)
                    --provenance false
                    containers/debian
                    2>&1 | tee build.log

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -84,6 +84,10 @@ EOF
 # Install updated compilers, with support for multiple base images
 ## Ubuntu: latest gcc from toolchain ppa, latest stable clang
 ## Debian: default gcc with distribution, latest stable clang
+## BUILDWEEK rotates weekly (format: YYYYwWW) to bust apt layer cache and
+## pick up compiler package updates that would otherwise be hidden by the
+## persistent registry layer cache.
+ARG BUILDWEEK=0
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked <<EOF
 . /etc/os-release

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="1c27427a9129b9e28a2bc15369ddb22085c7d567"
+EICSPACK_VERSION="425512532463029929b26692357dea5c1c04c89f"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="daeb4a2da40b25f38e58420af2c7b41737bc9f68"
+EICSPACK_VERSION="0ab6c6e0ebb3c3f6ac199a95b0b1d62fb8dbcd01"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="6cc06cacad0e7a6d802c67743d80257c01af664e"
+EICSPACK_VERSION="babd48646daabd886d0be2c2a99bc0658d1370d6"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="babd48646daabd886d0be2c2a99bc0658d1370d6"
+EICSPACK_VERSION="c7fbd1a14396e5e1de529a75e21e56889b9d8fb3"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -3,4 +3,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="c7fbd1a14396e5e1de529a75e21e56889b9d8fb3"
+EICSPACK_VERSION="daeb4a2da40b25f38e58420af2c7b41737bc9f68"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -512,7 +512,6 @@ packages:
     - '@0.13.2:'
   py-tensorflow:
     require:
-    - '%clang'
     - '@2.20'
   py-toml:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR unpins py-tensorflow from using clang (and mixing toolchains in our containers). It requires a few extra patches to tensorflow.

Changing the base image for runtime from cuda_devel to cuda_runtime.

Also, in the process of debugging this I realized that our base image from ghcr.io on GitHub Actions an the base image from eicweb on the Gitlab pipelines had a different gcc version (13.3.0 vs 13.4.0). This in turn meant inefficient spack buildcache use due to divergent package hashes. The split is caused by the more aggressive (successful) layer caching here and the higher buildcache churn on eicweb, so our containers/debian/Dockerfile was always reverting to the layer cache instead of installing a fresh compiler every once in a while. In order to avoid this, we introduce a base layer cache bust once a week.