### PR TITLE
fix: expose all NVIDIA driver capabilities in Dockerfile

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -113,6 +113,18 @@ jobs:
         uses: actions/checkout@v6
       - name: Inject enhanced GitHub environment variables
         uses: rlespinasse/github-slug-action@v5
+      - name: Load NVIDIA visible devices and driver capabilities
+        id: nvidia
+        shell: bash
+        run: |
+          case "${{ matrix.BUILD_IMAGE }}" in
+            cuda*)
+              NVIDIA_VISIBLE_DEVICES=all
+              NVIDIA_DRIVER_CAPABILITIES=all
+              ;;
+          esac
+          echo "visible_devices=${NVIDIA_VISIBLE_DEVICES}" | tee -a $GITHUB_OUTPUT
+          echo "driver_capabilities=${NVIDIA_DRIVER_CAPABILITIES}" | tee -a $GITHUB_OUTPUT
       - name: Load spack version and cherry-picks
         id: spack
         shell: bash
@@ -206,6 +218,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.BASE_IMAGE }}
             BUILD_IMAGE=${{ matrix.BUILD_IMAGE }}
+            NVIDIA_VISIBLE_DEVICES=${{ steps.nvidia.outputs.visible_devices }}
+            NVIDIA_DRIVER_CAPABILITIES=${{ steps.nvidia.outputs.driver_capabilities }}
             SPACK_ORGREPO=${{ steps.spack.outputs.orgrepo }}
             SPACK_VERSION=${{ steps.spack.outputs.version }}
             SPACK_SHA=${{ steps.spack.outputs.sha }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -328,6 +328,8 @@ base:
                    --platform ${PLATFORM}
                    --build-arg BASE_IMAGE=${BASE_IMAGE}
                    --build-arg BUILD_IMAGE=${BUILD_IMAGE}
+                   --build-arg NVIDIA_VISIBLE_DEVICES=$(case "${BUILD_IMAGE}" in cuda*) echo all ;; esac)
+                   --build-arg NVIDIA_DRIVER_CAPABILITIES=$(case "${BUILD_IMAGE}" in cuda*) echo all ;; esac)
                    --build-arg SPACK_ORGREPO=${SPACK_ORGREPO}
                    --build-arg SPACK_VERSION=${SPACK_VERSION}
                    --build-arg SPACK_SHA=$(sh .ci/resolve_git_ref "${SPACK_ORGREPO}" "${SPACK_VERSION}")

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -336,3 +336,9 @@ git clone --filter=tree:0 https://github.com/${EICSPACK_ORGREPO}.git ${EICSPACK_
 git -C ${EICSPACK_ROOT} checkout ${EICSPACK_SHA:-${EICSPACK_VERSION}}
 spack repo add --scope spack "${EICSPACK_ROOT}/spack_repo/eic"
 EOF
+
+## Ensure NVIDIA driver exposes all capabilities
+## https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
+ARG NVIDIA_VISIBLE_DEVICES
+ARG NVIDIA_DRIVER_CAPABILITIES
+ENV NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES} NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES}

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -454,7 +454,7 @@ RUN echo -e "\n - eic_container: ${CI_COMMIT_SHA}" | tee -a /etc/eic_info /etc/j
 ## Hotfix for misbehaving OSG nodes
 RUN mkdir /hadoop /localscratch
 
-## Ensure NVidia driver exposes graphics capabilities too
+## Ensure NVIDIA driver exposes all capabilities
 ## https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -456,5 +456,5 @@ RUN mkdir /hadoop /localscratch
 
 ## Ensure NVidia driver exposes graphics capabilities too
 ## https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES all
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -453,8 +453,3 @@ RUN echo -e "\n - eic_container: ${CI_COMMIT_SHA}" | tee -a /etc/eic_info /etc/j
 
 ## Hotfix for misbehaving OSG nodes
 RUN mkdir /hadoop /localscratch
-
-## Ensure NVIDIA driver exposes all capabilities
-## https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
-ENV NVIDIA_VISIBLE_DEVICES=all
-ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -453,3 +453,8 @@ RUN echo -e "\n - eic_container: ${CI_COMMIT_SHA}" | tee -a /etc/eic_info /etc/j
 
 ## Hotfix for misbehaving OSG nodes
 RUN mkdir /hadoop /localscratch
+
+## Ensure NVidia driver exposes graphics capabilities too
+## https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR may address https://github.com/eic/eic-spack/pull/866 better than sticking that in a spack package. Setting the variables on runtime after the container has already started has no effect. This ensures the environment variables are set by the time the NVIDIA code adds the libraries to the relevant library directories inside the container. More at https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#driver-capabilities and https://github.com/NVIDIA/nvidia-container-toolkit.

We could stick this in the base cuda_devel image too, but for now I'm sticking it here for faster testing (no rebuild).