### PR TITLE
z10_spack_environment.sh: don't set DETECTOR*

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -337,7 +337,7 @@ spack env activate --sh --dir ${SPACK_ENV} > /etc/profile.d/z10_spack_environmen
 # In container, the /etc/profile.d/z21_epic_main.sh is in charge of picking the
 # detector, unless specified externally by the user. As we install multiple detectors,
 # spack can not always pick the right one correctly.
-sed -i /etc/profile.d/z10_spack_environment.sh -e '/^export DETECTOR/d'
+sed -i -e '/^export DETECTOR/d' /etc/profile.d/z10_spack_environment.sh
 EOF
 
 ## Fixup /opt/detector/epic-git.fcf90937193c983c0af2acf1251e01f2e2c3a259_main

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -334,6 +334,10 @@ EOF
 RUN <<EOF
 set -e
 spack env activate --sh --dir ${SPACK_ENV} > /etc/profile.d/z10_spack_environment.sh
+# In container, the /etc/profile.d/z21_epic_main.sh is in charge of picking the
+# detector, unless specified externally by the user. As we install multiple detectors,
+# spack can not always pick the right one correctly.
+sed -i /etc/profile.d/z10_spack_environment.sh -e '/^export DETECTOR/d'
 EOF
 
 ## Fixup /opt/detector/epic-git.fcf90937193c983c0af2acf1251e01f2e2c3a259_main

--- a/containers/eic/profile.d/z21_epic_main.sh
+++ b/containers/eic/profile.d/z21_epic_main.sh
@@ -18,7 +18,9 @@ if test -z "$DETECTOR_PATH" -a -z "$DETECTOR_CONFIG" ; then
     fi
     thisepic=/opt/detector/epic-${version}/bin/thisepic.sh
     if test -f "$thisepic" ; then
-      . "$thisepic"
+      # Workaround for 26.04.0. After https://github.com/eic/epic/pull/1072 lands we can switch back to
+      # . "$thisepic"
+      eval "$(bash -c '. '"$thisepic"'; echo export DETECTOR=\"$DETECTOR\"; echo export DETECTOR_PATH=\"$DETECTOR_PATH\"; echo export DETECTOR_CONFIG=\"$DETECTOR_CONFIG\"; echo export DETECTOR_VERSION=\"$DETECTOR_VERSION\"')"
     fi
   fi
 fi


### PR DESCRIPTION
As discussed in https://github.com/eic/eic-spack/pull/856, the `/etc/profile.d/z10_spack_environment.sh` sets `DETECTOR_PATH` and `DETECTOR_CONFIG` to a wrong value when multiple detectors are present. In container, this is better handled by the `/etc/profile.d/z21_epic_main.sh`.