### PR TITLE
fix: remove LD_LIBRARY_PATH from epic's setup_run_environment

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="444a3e11a1fd5ad46d04231c94b08264444acf2c"
+EICSPACK_VERSION="3dc9e76edf4aad8cc6f377d320f3cead81e1ecae"


### PR DESCRIPTION
Resolves: https://github.com/eic/containers/issues/238

Merges https://github.com/eic/eic-spack/pull/856 and https://github.com/eic/eic-spack/pull/878 and pulls additional versions for algorithms, g4occt, eic-opticks without enabling them.