### PR TITLE
feat: upgrade py-uproot to v5.7.1 for RNTuple format v1.0.1.0 support

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -526,7 +526,7 @@ packages:
     - '@0.10.2:'
   py-uproot:
     require:
-    - '@5.7:'
+    - '@5.7:5'
   py-torch:
     require:
     - '@2.5.1'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -524,13 +524,13 @@ packages:
   py-toml:
     require:
     - '@0.10.2:'
-  py-uproot:
-    require:
-    - '@5.7:5'
   py-torch:
     require:
     - '@2.5.1'
     - -mkldnn
+  py-uproot:
+    require:
+    - '@5.7:5'
   py-vector:
     require:
     - '@1.5.1:'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -524,6 +524,9 @@ packages:
   py-toml:
     require:
     - '@0.10.2:'
+  py-uproot:
+    require:
+    - '@5.7:'
   py-torch:
     require:
     - '@2.5.1'

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -63,7 +63,6 @@ a896fdbe5d01981cbc6f9b5139a5d551ac2fe248
 read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 --- || true
 [50433a4a02370e9035b85820cd438a64d5433749]=repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
-[2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96]=repos/spack_repo/builtin/packages/py_uproot/package.py
 ---
 ## Ref: https://github.com/spack/spack-packages/commit/[hash]
 ## [hash]: [description]
@@ -110,4 +109,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2163a6ae2cad38980f67e8d617743cabfc773304: vecgeom: add v2.0.0
 ## 0d4e42deee0f561013568d1e92205a084cf203bc: g4hepem: new package
 ## 6346a54e35ee6281b8e8c6a1bc9c102893593c8e: g4adept: new package
-## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-uproot: add v5.7.1
+## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -55,6 +55,7 @@ a896fdbe5d01981cbc6f9b5139a5d551ac2fe248
 2163a6ae2cad38980f67e8d617743cabfc773304
 0d4e42deee0f561013568d1e92205a084cf203bc
 6346a54e35ee6281b8e8c6a1bc9c102893593c8e
+346babf5aebcf03045fbe10e59750fac8c95947f
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 ---
 ## Optional hash table with comma-separated file list
@@ -109,4 +110,5 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2163a6ae2cad38980f67e8d617743cabfc773304: vecgeom: add v2.0.0
 ## 0d4e42deee0f561013568d1e92205a084cf203bc: g4hepem: new package
 ## 6346a54e35ee6281b8e8c6a1bc9c102893593c8e: g4adept: new package
+## 346babf5aebcf03045fbe10e59750fac8c95947f: py-mplhep(-data): add new versions
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -55,6 +55,7 @@ a896fdbe5d01981cbc6f9b5139a5d551ac2fe248
 2163a6ae2cad38980f67e8d617743cabfc773304
 0d4e42deee0f561013568d1e92205a084cf203bc
 6346a54e35ee6281b8e8c6a1bc9c102893593c8e
+2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -62,6 +63,7 @@ a896fdbe5d01981cbc6f9b5139a5d551ac2fe248
 read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 --- || true
 [50433a4a02370e9035b85820cd438a64d5433749]=repos/spack_repo/builtin/packages/py_snakemake_interface_report_plugins/package.py
+[2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96]=repos/spack_repo/builtin/packages/py_uproot/package.py
 ---
 ## Ref: https://github.com/spack/spack-packages/commit/[hash]
 ## [hash]: [description]
@@ -108,3 +110,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2163a6ae2cad38980f67e8d617743cabfc773304: vecgeom: add v2.0.0
 ## 0d4e42deee0f561013568d1e92205a084cf203bc: g4hepem: new package
 ## 6346a54e35ee6281b8e8c6a1bc9c102893593c8e: g4adept: new package
+## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-uproot: add v5.7.1


### PR DESCRIPTION
## Problem

EICrecon PR [eic/EICrecon#2469](https://github.com/eic/EICrecon/pull/2469) converts CI output files from TTree to RNTuple format. The capybara comparison step fails because the eic-shell nightly container has **uproot 5.6.3**, which contains a bug in its array reading code for files written by ROOT 6.38.00 (RNTuple format v1.0.1.0).

## Root Cause

uproot 5.6.3, even with the eic-spack patches that add v1.0.1.0 footer support, uses `read_col_pages()` for array reading. For certain column configurations in v1.0.1.0 files, this function returns an empty buffer, causing:

```
TypeError: size of array (0) is less than size of form (100)
```

uproot 5.7.0 rewrote the array reading path, replacing `read_col_pages()` with `read_cluster_range()`, which correctly handles all v1.0.1.0 column configurations.

**Note**: The eic-spack patches (`88e69d47` for footer support, `ee1b1d55` for zigzag fix) only fix footer parsing — they do not fix the `read_col_pages` array reading bug.

## Changes

1. **`spack-packages.sh`**: Cherry-picks commit `2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96` from `spack/spack-packages` ("Python HEP arrays: add new versions for awkward, uproot, vector, and others"), restricted to `py_uproot/package.py` only, to make py-uproot@5.7.1 available.

2. **`spack-environment/packages.yaml`**: Adds `py-uproot: require: '@5.7:'` to force the container to use uproot 5.7.x.

## Related PRs

- EICrecon PR: [eic/EICrecon#2469](https://github.com/eic/EICrecon/pull/2469) — the RNTuple output PR that exposes this issue
- Capybara PR: [eic/epic-capybara#33](https://github.com/eic/epic-capybara/pull/33) — adds graceful error handling and bumps uproot requirement
