### PR TITLE
fix: g4occt-0.2.1

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -189,7 +189,7 @@ packages:
     - +covfie
   g4occt:
     require:
-    - '@git.v0.2.0'
+    - '@git.v0.2.1'
     - +dd4hep
   gaudi:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This pull request makes a minor update to the `spack-environment/packages.yaml` file, bumping the required version of the `@git` dependency for the `g4occt` package from `v0.2.0` to `v0.2.1`. This ensures the environment uses the latest compatible version of the dependency.

Fixes aarch64.

### What is the urgency of this PR?
- [x] High (reason: borked on master)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
