### PR TITLE
fix: use cache mount for spack bootstrap

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -291,7 +291,7 @@ spack config blame packages
 EOF
 
 ## Bootstrap
-RUN <<EOF
+RUN --mount=type=cache,target=/var/cache/spack <<EOF
 set -e
 spack bootstrap root /opt/spack/bootstrap
 spack bootstrap now


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
During spack bootstrap we download blobs from an OCI registry. This leaves traces in `/var/cache/spack`. With this PR we avoid that.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: build blobs retained in final container)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
