### PR TITLE
feat: set CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS=ON

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -323,7 +323,15 @@ EOF
 
 ## Set CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS to resolve symlinks in find_package
 ## directories to real paths, not generic <view>/include
-ENV CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS=ON
+COPY <<EOF /opt/local/etc/cmake/find_package_resolve_symlinks.cmake
+# Applied to every cmake project via CMAKE_TOOLCHAIN_FILE env var (CMake ≥ 3.21)
+
+# Resolve symlinks when computing package prefixes so packages found through
+# a Spack view (/opt/local → /opt/software/…/<hash>) expose their real,
+# package-specific include paths, not the merged view path.
+set(CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS ON)
+EOF
+ENV CMAKE_TOOLCHAIN_FILE=/opt/local/etc/cmake/find_package_resolve_symlinks.cmake
 
 ## Place cvmfs catalogs
 RUN <<EOF

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -321,6 +321,10 @@ mv /opt/._detector/${DETECTOR_PREFIX_PATH} /opt/detector
 ln -s /opt/detector /opt/._detector/${DETECTOR_PREFIX_PATH}
 EOF
 
+## Set CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS to resolve symlinks in find_package
+## directories to real paths, not generic <view>/include
+ENV CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS=ON
+
 ## Place cvmfs catalogs
 RUN <<EOF
 set -e


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR sets the environment variable `CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS` to resolve symlinks in CMake.

### What is the urgency of this PR?
- [ ] High
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: better support for in-container development)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Instead of a single de-duplicated `-I/opt/local/include` you will likely end up with many long paths in compilation commands.