### PR TITLE
fix: move spack blob cache eviction out of build steps to avoid race

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -906,7 +906,6 @@ spack-cache-cleanup:
   extends: .build
   stage: finalize
   when: always
-  needs: []
   allow_failure: true
   script:
     - docker buildx build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -910,8 +910,8 @@ spack-cache-cleanup:
   script:
     - docker buildx build
         --target spack_cache_cleanup
-        --file containers/eic/Dockerfile
-        containers/eic
+        --file containers/eic/Dockerfile.spack-cache-cleanup
+        .
 
 status:success:
   stage: status-report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -902,6 +902,18 @@ clean_pipeline:docker-new:
   tags:
     - docker-new
 
+spack-cache-cleanup:
+  extends: .build
+  stage: finalize
+  when: always
+  needs: []
+  allow_failure: true
+  script:
+    - docker buildx build
+        --target spack_cache_cleanup
+        --file containers/eic/Dockerfile
+        containers/eic
+
 status:success:
   stage: status-report
   dependencies: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -909,6 +909,7 @@ spack-cache-cleanup:
   allow_failure: true
   script:
     - docker buildx build
+        --no-cache
         --target spack_cache_cleanup
         --file containers/eic/Dockerfile.spack-cache-cleanup
         .

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -436,10 +436,10 @@ SHELL ["/opt/local/bin/eic-shell"]
 ## ========================================================================================
 FROM debian:trixie-slim AS spack_cache_cleanup
 
-ARG EVICT_ATIME=7
+ARG EVICT_MTIME=7
 RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
 mkdir -p /var/cache/spack/blobs/sha256
-find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +${EVICT_ATIME} -delete
+find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_MTIME} -delete
 EOF
 
 

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -102,8 +102,6 @@ RUN --mount=type=cache,target=/ccache,id=ccache-${TARGETPLATFORM}              \
     <<EOF
 set -e
 export CCACHE_DIR=/ccache
-mkdir -p /var/cache/spack/blobs/sha256/
-find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +7 -delete
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
 spack clean --downloads --stage
 ccache --show-stats
@@ -428,6 +426,20 @@ CMD ["bash", "--rcfile", "/etc/profile", "-l"]
 USER 0
 WORKDIR /
 SHELL ["/opt/local/bin/eic-shell"]
+
+## ========================================================================================
+## spack_cache_cleanup
+## - standalone target to evict stale blobs from the shared spack builder cache
+## - run this AFTER all build jobs complete (never during a build) to avoid the race
+##   condition where concurrent builds delete blobs each other still need
+## - sharing=locked serialises cleanup with any concurrent pipeline on the same daemon
+## ========================================================================================
+FROM debian:trixie-slim AS spack_cache_cleanup
+
+ARG EVICT_ATIME=7
+RUN --mount=type=cache,target=/var/cache/spack,sharing=locked \
+    find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +${EVICT_ATIME} -delete
+
 
 ## rucio config (unprivileged read-only account)
 COPY <<EOF /opt/rucio/etc/rucio.cfg

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -427,22 +427,6 @@ USER 0
 WORKDIR /
 SHELL ["/opt/local/bin/eic-shell"]
 
-## ========================================================================================
-## spack_cache_cleanup
-## - standalone target to evict stale blobs from the shared spack builder cache
-## - run this AFTER all build jobs complete (never during a build) to avoid the race
-##   condition where concurrent builds delete blobs each other still need
-## - sharing=locked serialises cleanup with any concurrent pipeline on the same daemon
-## ========================================================================================
-FROM debian:trixie-slim AS spack_cache_cleanup
-
-ARG EVICT_MTIME=7
-RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
-mkdir -p /var/cache/spack/blobs/sha256
-find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_MTIME} -delete
-EOF
-
-
 ## rucio config (unprivileged read-only account)
 COPY <<EOF /opt/rucio/etc/rucio.cfg
 [client]

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -437,8 +437,10 @@ SHELL ["/opt/local/bin/eic-shell"]
 FROM debian:trixie-slim AS spack_cache_cleanup
 
 ARG EVICT_ATIME=7
-RUN --mount=type=cache,target=/var/cache/spack,sharing=locked \
-    find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +${EVICT_ATIME} -delete
+RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
+mkdir -p /var/cache/spack/blobs/sha256
+find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -atime +${EVICT_ATIME} -delete
+EOF
 
 
 ## rucio config (unprivileged read-only account)

--- a/containers/eic/Dockerfile.spack-cache-cleanup
+++ b/containers/eic/Dockerfile.spack-cache-cleanup
@@ -1,0 +1,17 @@
+#syntax=docker/dockerfile:1.10
+#check=error=true
+
+## ========================================================================================
+## spack_cache_cleanup
+## - standalone target to evict stale blobs from the shared spack builder cache
+## - run this AFTER all build jobs complete (never during a build) to avoid the race
+##   condition where concurrent builds delete blobs each other still need
+## - sharing=locked serialises cleanup with any concurrent pipeline on the same daemon
+## ========================================================================================
+FROM debian:trixie-slim AS spack_cache_cleanup
+
+ARG EVICT_MTIME=7
+RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
+mkdir -p /var/cache/spack/blobs/sha256
+find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_MTIME} -delete
+EOF

--- a/containers/eic/Dockerfile.spack-cache-cleanup
+++ b/containers/eic/Dockerfile.spack-cache-cleanup
@@ -5,14 +5,18 @@
 ## spack_cache_cleanup
 ## - standalone target to evict stale blobs from the shared spack builder cache
 ## - run this AFTER all build jobs complete (never during a build) to avoid the race
+## - eviction intentionally uses modification time (`find -mtime`), not access time
+##   (`-atime`), because this cleanup runs on a shared cache and should not depend on
+##   filesystem access-time tracking being enabled or updated consistently
+## - run this AFTER all build jobs complete (never during a build) to avoid the race
 ##   condition where concurrent builds delete blobs each other still need
 ## - sharing=locked serialises cleanup with any concurrent pipeline on the same daemon
 ## ========================================================================================
 FROM debian:trixie-slim AS spack_cache_cleanup
 
-ARG EVICT_MTIME=7
+ARG EVICT_DAYS=7
 RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
-set -e
 mkdir -p /var/cache/spack/blobs/sha256
-find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_MTIME} -delete
+# Use modification time for eviction age; do not rely on access time for this cache.
+find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_DAYS} -delete
 EOF

--- a/containers/eic/Dockerfile.spack-cache-cleanup
+++ b/containers/eic/Dockerfile.spack-cache-cleanup
@@ -12,6 +12,7 @@ FROM debian:trixie-slim AS spack_cache_cleanup
 
 ARG EVICT_MTIME=7
 RUN --mount=type=cache,target=/var/cache/spack,sharing=locked <<EOF
+set -e
 mkdir -p /var/cache/spack/blobs/sha256
 find /var/cache/spack/blobs/sha256/ -ignore_readdir_race -mtime +${EVICT_MTIME} -delete
 EOF


### PR DESCRIPTION
## Problem

Multiple concurrent `eic` matrix jobs on the same GitLab CI runner share the same `/var/cache/spack` BuildKit cache mount (no `id=` suffix, so all share one mount). On filesystems with `noatime` (common for performance), reading a blob does **not** update its `atime`.

The race condition:
1. **Job A** (`ENV=xl`) `builder_installation_default` reads blob X (atime stays old due to noatime)
2. **Job B** (`ENV=ci`) `builder_installation_default` starts concurrently, runs `find ... -atime +7 -delete` and **deletes blob X**
3. **Job A**'s `runtime_installation_default` runs `spack install --use-buildcache only` and fails:
   ```
   FileNotFoundError: [Errno 2] No such file or directory: '/var/cache/spack/blobs/sha256/<hash>'
   ```

Example failure: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7641974

## Fix

**Key principle:** eviction must never happen while any build job is active.

- **Remove** `mkdir -p` and `find ... -atime +7 -delete` from `builder_installation_default` so no eviction occurs during a build.
- **Add** a standalone `spack_cache_cleanup` Dockerfile target (based on `debian:trixie-slim`) with `--mount=type=cache,target=/var/cache/spack,sharing=locked` that runs the same eviction. `sharing=locked` serialises cleanup against any concurrently running build stage on the same BuildKit daemon.
- **Add** a `spack-cache-cleanup` GitLab CI job in the `finalize` stage (`when: always`, `allow_failure: true`) that builds this target after all `eic` matrix jobs have completed.