### PR TITLE
z21_epic_main.sh: undo workaround

### DIFF
--- a/containers/eic/profile.d/z21_epic_main.sh
+++ b/containers/eic/profile.d/z21_epic_main.sh
@@ -18,9 +18,7 @@ if test -z "$DETECTOR_PATH" -a -z "$DETECTOR_CONFIG" ; then
     fi
     thisepic=/opt/detector/epic-${version}/bin/thisepic.sh
     if test -f "$thisepic" ; then
-      # Workaround for 26.04.0. After https://github.com/eic/epic/pull/1072 lands we can switch back to
-      # . "$thisepic"
-      eval "$(bash -c '. '"$thisepic"'; echo export DETECTOR=\"$DETECTOR\"; echo export DETECTOR_PATH=\"$DETECTOR_PATH\"; echo export DETECTOR_CONFIG=\"$DETECTOR_CONFIG\"; echo export DETECTOR_VERSION=\"$DETECTOR_VERSION\"')"
+      . "$thisepic"
     fi
   fi
 fi


### PR DESCRIPTION
The workaround is incomplete anyways, because we do need to extract an updated LD_LIBRARY_PATH.