### PR TITLE
ci: add artifact download links to capybara PR comment

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -702,7 +702,8 @@ jobs:
           -N 100 \
           --outputFile sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root \
           -v WARNING
-    - uses: actions/upload-artifact@v7
+    - id: upload_new_artifact
+      uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         path: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
@@ -725,6 +726,20 @@ jobs:
         capybara bara ref/sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root* sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
         mv capybara-reports sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
         touch .sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
+    - name: Write artifact metadata
+      run: |
+        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
+        REF_URL=""
+        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
+          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+          if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
+            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+          fi
+        fi
+        jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
+          > sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}/meta.json
     - uses: actions/upload-artifact@v7
       with:
         name: sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.capy
@@ -762,7 +777,8 @@ jobs:
           -N 100 --inputFiles ${url} --random.seed 1 \
           --outputFile sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root \
           -v WARNING
-    - uses: actions/upload-artifact@v7
+    - id: upload_new_artifact
+      uses: actions/upload-artifact@v7
       with:
         name: sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root
         path: sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root
@@ -785,6 +801,20 @@ jobs:
         capybara bara ref/sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root* sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root
         mv capybara-reports sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
         touch .sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
+    - name: Write artifact metadata
+      run: |
+        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
+        REF_URL=""
+        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
+          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+          if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
+            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+          fi
+        fi
+        jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
+          > sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}/meta.json
     - uses: actions/upload-artifact@v7
       with:
         name: sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.capy
@@ -819,7 +849,8 @@ jobs:
         eicrecon \
           -Ppodio:output_file=rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root \
           sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4hep.root
-    - uses: actions/upload-artifact@v7
+    - id: upload_new_artifact
+      uses: actions/upload-artifact@v7
       with:
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         path: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
@@ -844,6 +875,20 @@ jobs:
         capybara bara ref/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root* new/rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.edm4eic.root
         mv capybara-reports rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
         touch .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
+    - name: Write artifact metadata
+      run: |
+        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
+        REF_URL=""
+        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
+          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+          if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
+            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+          fi
+        fi
+        jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
+          > rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}/meta.json
     - uses: actions/upload-artifact@v7
       with:
         name: rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}.capy
@@ -882,7 +927,8 @@ jobs:
         eicrecon \
           -Ppodio:output_file=rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root \
           sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4hep.root
-    - uses: actions/upload-artifact@v7
+    - id: upload_new_artifact
+      uses: actions/upload-artifact@v7
       with:
         name: rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root
         path: rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root
@@ -907,6 +953,20 @@ jobs:
         capybara bara ref/rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root* new/rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.edm4eic.root
         mv capybara-reports rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
         touch .rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
+    - name: Write artifact metadata
+      run: |
+        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
+        REF_URL=""
+        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
+          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+          if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
+            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+          fi
+        fi
+        jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
+          > rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}/meta.json
     - uses: actions/upload-artifact@v7
       with:
         name: rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}.capy
@@ -990,8 +1050,18 @@ jobs:
       if: github.ref_name == 'master' || steps.download_capybara.outputs.found_artifact == 'true'
       run: |
         echo "### Capybara summary for master" >> publishing_docs/capybara/index.md
-        find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d -printf \
-          "- [%f](https://eic.github.io/containers/capybara/%f/index.html)\n" | sort >> publishing_docs/capybara/index.md
+        while IFS= read -r dir; do
+          name=$(basename "$dir")
+          line="- [${name}](https://eic.github.io/containers/capybara/${name}/index.html)"
+          if [ -f "${dir}/meta.json" ]; then
+            new_url=$(jq -r '.new // empty' "${dir}/meta.json" 2>/dev/null || true)
+            ref_url=$(jq -r '.ref // empty' "${dir}/meta.json" 2>/dev/null || true)
+            [ -n "$new_url" ] && line="${line} ([new artifact](${new_url}))"
+            [ -n "$ref_url" ] && line="${line} ([ref artifact](${ref_url}))"
+          fi
+          echo "$line"
+        done < <(find publishing_docs/capybara/ -mindepth 1 -maxdepth 1 -type d | sort) \
+          >> publishing_docs/capybara/index.md
     - name: Create capybara step summary (on master)
       if: github.ref_name == 'master'
       run: |
@@ -1041,11 +1111,21 @@ jobs:
       run: |
         echo "### Capybara summary for PR ${{ github.event.pull_request.number }}" \
           >> capybara_${{ github.event.pull_request.number }}.md
-        [ -d publishing_docs/pr/${{ github.event.pull_request.number }}/capybara/ ] && \
-          find publishing_docs/pr/${{ github.event.pull_request.number }}/capybara/ \
-            -mindepth 1 -maxdepth 1 -type d \
-            -printf "- [%f](https://eic.github.io/containers/pr/${{ github.event.pull_request.number }}/capybara/%f/index.html)\n" \
-            | sort >> capybara_${{ github.event.pull_request.number }}.md || true
+        CAPY_DIR="publishing_docs/pr/${{ github.event.pull_request.number }}/capybara"
+        if [ -d "$CAPY_DIR" ]; then
+          while IFS= read -r dir; do
+            name=$(basename "$dir")
+            line="- [${name}](https://eic.github.io/containers/pr/${{ github.event.pull_request.number }}/capybara/${name}/index.html)"
+            if [ -f "${dir}/meta.json" ]; then
+              new_url=$(jq -r '.new // empty' "${dir}/meta.json" 2>/dev/null || true)
+              ref_url=$(jq -r '.ref // empty' "${dir}/meta.json" 2>/dev/null || true)
+              [ -n "$new_url" ] && line="${line} ([new artifact](${new_url}))"
+              [ -n "$ref_url" ] && line="${line} ([ref artifact](${ref_url}))"
+            fi
+            echo "$line"
+          done < <(find "$CAPY_DIR" -mindepth 1 -maxdepth 1 -type d | sort) \
+            >> capybara_${{ github.event.pull_request.number }}.md
+        fi
         echo "<sup><sub>Last updated $(TZ=America/New_York date -Iminutes) ${{ github.event.pull_request.head.sha }}</sub></sup>" \
           >> capybara_${{ github.event.pull_request.number }}.md
     - name: Create capybara step summary

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -727,15 +727,18 @@ jobs:
         mv capybara-reports sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
         touch .sim_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
     - name: Write artifact metadata
+      env:
+        NEW_URL: ${{ steps.upload_new_artifact.outputs.artifact-url }}
+        FOUND_ARTIFACT: ${{ steps.download_previous_artifact.outputs.found_artifact }}
+        REF_ARTIFACTS: ${{ steps.download_previous_artifact.outputs.artifacts }}
+        REPOSITORY: ${{ github.repository }}
       run: |
-        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
         REF_URL=""
-        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
-          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+        if [ "$FOUND_ARTIFACT" = "true" ]; then
           REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
           REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
           if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
-            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+            REF_URL="https://github.com/$REPOSITORY/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
           fi
         fi
         jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
@@ -802,15 +805,18 @@ jobs:
         mv capybara-reports sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
         touch .sim_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
     - name: Write artifact metadata
+      env:
+        NEW_URL: ${{ steps.upload_new_artifact.outputs.artifact-url }}
+        FOUND_ARTIFACT: ${{ steps.download_previous_artifact.outputs.found_artifact }}
+        REF_ARTIFACTS: ${{ steps.download_previous_artifact.outputs.artifacts }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
-        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
         REF_URL=""
-        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
-          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
+        if [ "$FOUND_ARTIFACT" = "true" ]; then
           REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
           REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
           if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
-            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+            REF_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
           fi
         fi
         jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
@@ -876,15 +882,18 @@ jobs:
         mv capybara-reports rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
         touch .rec_${{ matrix.particle }}_1GeV_20GeV_${{ matrix.detector_config }}
     - name: Write artifact metadata
+      env:
+        NEW_URL: ${{ steps.upload_new_artifact.outputs.artifact-url }}
+        FOUND_ARTIFACT: ${{ steps.download_previous_artifact.outputs.found_artifact }}
+        REF_ARTIFACTS_JSON: ${{ steps.download_previous_artifact.outputs.artifacts }}
+        GITHUB_REPOSITORY_NAME: ${{ github.repository }}
       run: |
-        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
         REF_URL=""
-        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
-          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
-          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
-          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+        if [ "$FOUND_ARTIFACT" = "true" ]; then
+          REF_ART_ID=$(echo "$REF_ARTIFACTS_JSON" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS_JSON" | jq -r '.[0].workflow_run.id // empty')
           if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
-            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+            REF_URL="https://github.com/${GITHUB_REPOSITORY_NAME}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
           fi
         fi
         jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \
@@ -954,15 +963,18 @@ jobs:
         mv capybara-reports rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
         touch .rec_dis_${{ matrix.beam }}_minQ2=${{ matrix.minq2 }}_${{ matrix.detector_config }}
     - name: Write artifact metadata
+      env:
+        NEW_URL: ${{ steps.upload_new_artifact.outputs.artifact-url }}
+        FOUND_ARTIFACT: ${{ steps.download_previous_artifact.outputs.found_artifact }}
+        REF_ARTIFACTS_JSON: ${{ steps.download_previous_artifact.outputs.artifacts }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
-        NEW_URL="${{ steps.upload_new_artifact.outputs.artifact-url }}"
         REF_URL=""
-        if [ "${{ steps.download_previous_artifact.outputs.found_artifact }}" = "true" ]; then
-          REF_ARTIFACTS='${{ steps.download_previous_artifact.outputs.artifacts }}'
-          REF_ART_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].id // empty')
-          REF_RUN_ID=$(echo "$REF_ARTIFACTS" | jq -r '.[0].workflow_run.id // empty')
+        if [ "$FOUND_ARTIFACT" = "true" ]; then
+          REF_ART_ID=$(echo "$REF_ARTIFACTS_JSON" | jq -r '.[0].id // empty')
+          REF_RUN_ID=$(echo "$REF_ARTIFACTS_JSON" | jq -r '.[0].workflow_run.id // empty')
           if [ -n "$REF_ART_ID" ] && [ -n "$REF_RUN_ID" ]; then
-            REF_URL="https://github.com/${{ github.repository }}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
+            REF_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${REF_RUN_ID}/artifacts/${REF_ART_ID}"
           fi
         fi
         jq -nc --arg new "$NEW_URL" --arg ref "$REF_URL" '{new: $new, ref: $ref}' \


### PR DESCRIPTION
## Summary

For each entry in the capybara comparison PR comment, this PR adds direct download links to the **new** (feature branch) and **ref** (target branch) ROOT artifacts that were compared.

**Before:**
```
- [rec_dis_10x100_minQ2=1000_epic_craterlake](https://eic.github.io/containers/pr/172/capybara/rec_dis_10x100_minQ2=1000_epic_craterlake/index.html)
```

**After:**
```
- [rec_dis_10x100_minQ2=1000_epic_craterlake](https://eic.github.io/containers/pr/172/capybara/rec_dis_10x100_minQ2=1000_epic_craterlake/index.html) ([new artifact](https://github.com/eic/containers/actions/runs/.../artifacts/...)) ([ref artifact](https://github.com/eic/containers/actions/runs/.../artifacts/...))
```

## Implementation

- In each of `npsim-gun`, `npsim-dis`, `eicrecon-gun`, `eicrecon-dis`: adds a `Write artifact metadata` step after the capybara comparison that writes a `meta.json` into the capybara report directory. This file holds the `artifact-url` from `actions/upload-artifact` (new) and a URL constructed from `dawidd6/action-download-artifact`'s `artifacts` output (ref).
- The `meta.json` is picked up by the existing `.capy` artifact upload and flows through `merge-capybara` into the GitHub Pages staging.
- The PR comment and master summary steps are updated to read `meta.json` and append the download links.

Links require GitHub authentication to download (standard for Actions artifacts). If the ref artifact was not found, the ref link is simply omitted.