### PR TITLE
fix: (py-)protobuf: v*.28.{2 -> 3}

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -380,7 +380,7 @@ packages:
     - +plot
   protobuf:
     require:
-    - '@28.2'
+    - '@28.3'
   pyrobird:
     require:
     - '@0.1.23:'
@@ -495,7 +495,7 @@ packages:
     - '@3.6.0:'
   py-protobuf:
     require:
-    - '@5.28.2'
+    - '@5.28.3'
   py-pygithub:
     require:
     - '@2.1.1:'

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -20,6 +20,7 @@ f5742718da7bd1d078ddc8423011a82ef2e3c759
 6346a54e35ee6281b8e8c6a1bc9c102893593c8e
 f0ff58aff997ab3c4c0598e0ccdfd662a06d1233
 bd32638d817fa66188880e557196acd2a5d6e7b6
+b17f3abec760256ad7faf1b1d102f2553d6a3622
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -37,3 +38,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 6346a54e35ee6281b8e8c6a1bc9c102893593c8e: g4adept: new package
 ## f0ff58aff997ab3c4c0598e0ccdfd662a06d1233: py-tf2onnx: add v1.17.0 (new package)
 ## bd32638d817fa66188880e557196acd2a5d6e7b6: py-tf2onnx: depends on py-tensorflow
+## b17f3abec760256ad7faf1b1d102f2553d6a3622: (py-)protobuf: add v(5.)28.3


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
TensorFlow vendors protobuf 5.28.3, and a runtime version consistency check causes TensorFlow to fail to load. This PR ensures that protobuf is at the right version.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7738352#L3)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
