### PR TITLE
chore: npsim-1.4.7

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="b9020a1f6d9856918c23ebc48f5309bbafa4e1e8"
+EICSPACK_VERSION="dcd894ea9bfdecacc47c16d42b52ae15bbb76836"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="0efb894cfa50bce75efb0c06d05b4e4bd013da68"
+EICSPACK_VERSION="b9020a1f6d9856918c23ebc48f5309bbafa4e1e8"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -323,7 +323,7 @@ packages:
     - '@0.0.3'
   npsim:
     require:
-    - '@1.4.6'
+    - '@1.5.1'
     - +http
     - any_of: [+geocad, -geocad]
   ollama:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -323,7 +323,7 @@ packages:
     - '@0.0.3'
   npsim:
     require:
-    - '@1.5.1'
+    - '@1.4.7'
     - +http
     - any_of: [+geocad, -geocad]
   ollama:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR upgrades `npsim` from 1.4.6 to 1.4.7.

Additional potential changes by bumping eic-spack:
- dcd894e (HEAD -> develop, origin/develop, origin/HEAD) npsim: add v1.4.7
- d3af8c2 New package versions found for eicrecon (#899)
- b9020a1 npsim: add v1.5.1, add tag eic (#900)
- 06f5283 eic-smear: depends_on hepmc3 +rootio when @1.1.10: (#893)
- 82b78c8 dd4hep: display compatibility notice when older geometry is used with Geant4TVUserParticleHandler (#896)
- 8ec5817 feat: npsim 1.5.0
- c218b01 online-distribution: add new package with ePIC branch version (#895)
- 706e933 eicrecon: depends on root +tmva when @1.14: (#894)
- be3010d feat: add rntuple variant to py-epic-capybara (#891)

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

This unblocks the DIRC simulations.