### PR TITLE
fix: only concretize eic_tf on gh but don't build

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -438,7 +438,7 @@ jobs:
           arch: amd64
           runner: ubuntu-latest
           PLATFORM: linux/amd64
-          target: final
+          target: builder_concretization_default
           SPACK_DUPLICATE_ALLOWLIST: "epic|llvm|py-setuptools|py-urllib3|py-dask|py-dask-awkward|py-dask-histogram|py-distributed|py-requests"
       fail-fast: false
     steps:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR changes the strategy for eic_tf to only concretize the environment on GitHub but stops it from being built on GitHub.

TensorFlow takes more than 6 hours to build on GitHub so it times out. We therefore essentially rely on already having a build in the cache, which only happens (at best) on the second time we run the job and eicweb has already populated it there.

Moreover, until #227 there is the potential for divergence in the exact conditions of the container builds between GitHub amd eicweb, so lately we don't even match the hash of TensorFlow between GitHub and eicweb anymore either. See https://github.com/eic/containers/actions/runs/25470306644 for current default branch failure.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/containers/actions/runs/25470306644)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

eic_tf has started to fail to build quite consistently on GitHub, and is tying up runners for 6 hours at a time.