### PR TITLE
fix: use github.com/eic for benchmarks

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -453,10 +453,9 @@ jobs:
         id: benchmarks
         shell: bash
         run: |
-          echo "common_bench=$(.ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git master)" | tee -a $GITHUB_OUTPUT
-          echo "detector_benchmarks=$(.ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks.git master)" | tee -a $GITHUB_OUTPUT
-          echo "reconstruction_benchmarks=$(.ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git master)" | tee -a $GITHUB_OUTPUT
-          echo "physics_benchmarks=$(.ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks.git master)" | tee -a $GITHUB_OUTPUT
+          echo "common_bench=$(.ci/resolve_git_ref https://github.com/eic/common_bench.git master)" | tee -a $GITHUB_OUTPUT
+          echo "detector_benchmarks=$(.ci/resolve_git_ref https://github.com/eic/detector_benchmarks.git master)" | tee -a $GITHUB_OUTPUT
+          echo "physics_benchmarks=$(.ci/resolve_git_ref https://github.com/eic/physics_benchmarks.git master)" | tee -a $GITHUB_OUTPUT
       - name: Resolve campaign versions
         id: campaigns
         shell: bash
@@ -551,7 +550,6 @@ jobs:
           build-args: |
             BENCHMARK_COM_SHA=${{ steps.benchmarks.outputs.common_bench }}
             BENCHMARK_DET_SHA=${{ steps.benchmarks.outputs.detector_benchmarks }}
-            BENCHMARK_REC_SHA=${{ steps.benchmarks.outputs.reconstruction_benchmarks }}
             BENCHMARK_PHY_SHA=${{ steps.benchmarks.outputs.physics_benchmarks }}
             CAMPAIGNS_HEPMC3_SHA=${{ steps.campaigns.outputs.simulation_campaign_hepmc3 }}
             CAMPAIGNS_CONDOR_SHA=${{ steps.campaigns.outputs.job_submission_condor }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -454,10 +454,9 @@ eic:
                    }
                    --file containers/eic/Dockerfile
                    --platform ${PLATFORM}
-                   --build-arg BENCHMARK_COM_SHA=$(sh .ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git master)
-                   --build-arg BENCHMARK_DET_SHA=$(sh .ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks.git master)
-                   --build-arg BENCHMARK_REC_SHA=$(sh .ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git master)
-                   --build-arg BENCHMARK_PHY_SHA=$(sh .ci/resolve_git_ref https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks.git master)
+                   --build-arg BENCHMARK_COM_SHA=$(sh .ci/resolve_git_ref https://github.com/eic/common_bench.git master)
+                   --build-arg BENCHMARK_DET_SHA=$(sh .ci/resolve_git_ref https://github.com/eic/detector_benchmarks.git master)
+                   --build-arg BENCHMARK_PHY_SHA=$(sh .ci/resolve_git_ref https://github.com/eic/physics_benchmarks.git master)
                    --build-arg CAMPAIGNS_HEPMC3_SHA=$(sh .ci/resolve_git_ref eic/simulation_campaign_hepmc3 main)
                    --build-arg CAMPAIGNS_CONDOR_SHA=$(sh .ci/resolve_git_ref eic/job_submission_condor main)
                    --build-arg CAMPAIGNS_SLURM_SHA=$(sh .ci/resolve_git_ref eic/job_submission_slurm main)

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -403,18 +403,14 @@ EOF
 ## Install benchmarks into the container
 ARG BENCHMARK_COM_SHA=""
 ARG BENCHMARK_DET_SHA=""
-ARG BENCHMARK_REC_SHA=""
 ARG BENCHMARK_PHY_SHA=""
 RUN <<EOF
-git clone https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git /opt/benchmarks/common_bench
+git clone https://github.com/eic/common_bench.git /opt/benchmarks/common_bench
 git -C /opt/benchmarks/common_bench checkout ${BENCHMARK_COM_SHA:-master}
-git clone https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks.git /opt/benchmarks/detector_benchmarks
+git clone https://github.com/eic/detector_benchmarks.git /opt/benchmarks/detector_benchmarks
 git -C /opt/benchmarks/detector_benchmarks checkout ${BENCHMARK_DET_SHA:-master}
 ln -sf /opt/benchmarks/common_bench /opt/benchmarks/detector_benchmarks/.local
-git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git /opt/benchmarks/reconstruction_benchmarks
-git -C /opt/benchmarks/reconstruction_benchmarks checkout ${BENCHMARK_REC_SHA:-master}
-ln -sf /opt/benchmarks/common_bench /opt/benchmarks/reconstruction_benchmarks/.local
-git clone https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks.git /opt/benchmarks/physics_benchmarks
+git clone https://github.com/eic/physics_benchmarks.git /opt/benchmarks/physics_benchmarks
 git -C /opt/benchmarks/physics_benchmarks checkout ${BENCHMARK_PHY_SHA:-master}
 ln -sf /opt/benchmarks/common_bench /opt/benchmarks/physics_benchmarks/.local
 EOF


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR updates the container build to use the benchmarks on github. Since our common_bench there is now disconnected from the original eicweb common_bench, this is a requirement to get the correct interfaces.

This PR also removes the obsolete reconstruction benchmarks from the container.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: fix mismatched common_bench)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
