### PR TITLE
fix: rm reconstruction benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -714,29 +714,6 @@ benchmarks:physics:nightly:
     project: EIC/benchmarks/physics_benchmarks
     strategy: depend
 
-benchmarks:reconstruction:default:
-  extends: .benchmarks:default
-  rules:
-   - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
-  variables:
-    BENCHMARKS_CONTAINER: eic_ci
-    BENCHMARKS_TAG: "${INTERNAL_TAG}-default"
-  trigger:
-    project: EIC/benchmarks/reconstruction_benchmarks
-    strategy: depend
-
-benchmarks:reconstruction:nightly:
-  extends: .benchmarks:nightly
-  rules:
-    - !reference ['.nightly', rules]
-    - if: '$CI_PIPELINE_SOURCE != "schedule" && $EICRECON_VERSION == ""'
-  variables:
-    BENCHMARKS_CONTAINER: eic_ci
-    BENCHMARKS_TAG: "${INTERNAL_TAG}-nightly"
-  trigger:
-    project: EIC/benchmarks/reconstruction_benchmarks
-    strategy: depend
-
 df:
   extends: .build
   stage: config


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes the reconstruction benchmarks jobs from the GitLab CI configuration. Repositories have been archived.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: legacy, analysis in https://github.com/eic/reconstruction_benchmarks/issues/1)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Analysis in https://github.com/eic/reconstruction_benchmarks/issues/1 was generated with copilot.