### PR TITLE
feat: add waterfall:upload job and link GitHub status to Perfetto launcher

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -918,6 +918,7 @@ waterfall:upload:
   image: alpine:latest
   rules:
     - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
+      when: always
   before_script:
     - apk add --no-cache curl jq
   script:
@@ -927,5 +928,4 @@ waterfall:upload:
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:
     GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
-  when: always
   allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,5 +922,5 @@ waterfall:upload:
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:
-    GITHUB_PAGES_TOKEN: ${GITHUB_PAGES_TOKEN}
+    GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
   when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -894,6 +894,24 @@ spack-cache-cleanup:
         --file containers/eic/Dockerfile.spack-cache-cleanup
         .
 
+waterfall:upload:
+  stage: waterfall
+  dependencies: []
+  extends: .status
+  variables:
+    STATUS: "success"
+    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
+    STATUS_CONTEXT: "eic/perfetto-launcher"
+    DESCRIPTION: "Perfetto trace available"
+    GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
+  when: always
+  before_script:
+    - apk add --no-cache curl jq python3
+    - |
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
+           -o waterfall-eicweb.sh
+      sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
+
 status:success:
   stage: status-report
   dependencies: []
@@ -911,19 +929,3 @@ status:failure:
     STATE: "failure"
     DESCRIPTION: "Failed!"
   when: on_failure
-
-waterfall:upload:
-  stage: waterfall
-  image: alpine:latest
-  rules:
-    - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
-      when: always
-  before_script:
-    - apk add --no-cache curl jq python3
-    - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
-           -o waterfall-eicweb.sh
-      sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
-  variables:
-    GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
-  allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -909,7 +909,7 @@ waterfall:upload:
   before_script:
     - apk add --no-cache curl jq python3
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/9a8861f888ff948c8bc277562d4d81f3b8f2acd0/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,6 +176,7 @@ version:
   before_script: []
   variables:
     STATUS_TARGET_URL: "${CI_PIPELINE_URL}"
+    STATUS_CONTEXT: "eicweb/eic_container"
   script:
     - |
       curl \
@@ -186,7 +187,7 @@ version:
         -d '{"state":"'"${STATE}"'",
               "target_url":"'"${STATUS_TARGET_URL}"'",
               "description":"'"${DESCRIPTION} $(TZ=America/New_York date)"'",
-              "context":"eicweb/eic_container"
+              "context":"'"${STATUS_CONTEXT}"'"
             }' ;
 
 status:pending:
@@ -926,6 +927,16 @@ waterfall:upload:
       curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
+      curl \
+        -X POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
+        "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+        -d '{"state":"success",
+              "target_url":"'"https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"'",
+              "description":"Perfetto trace available",
+              "context":"eic/perfetto-launcher"
+            }' ;
   variables:
     GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
   allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,7 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/8b856e11e8b546b526a5b6b705c44ed5c12839a5/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/28a328e21626b078a9de081ae92dca0255911c65/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -920,7 +920,7 @@ waterfall:upload:
     - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
       when: always
   before_script:
-    - apk add --no-cache curl jq
+    - apk add --no-cache curl jq python3
   script:
     - |
       curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -898,6 +898,7 @@ waterfall:upload:
   stage: waterfall
   dependencies: []
   extends: .status
+  image: alpine:latest
   variables:
     STATE: "success"
     STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -901,7 +901,6 @@ status:success:
   variables:
     STATE: "success"
     DESCRIPTION: "Succeeded!"
-    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
   when: on_success
 
 status:failure:
@@ -911,7 +910,6 @@ status:failure:
   variables:
     STATE: "failure"
     DESCRIPTION: "Failed!"
-    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
   when: on_failure
 
 waterfall:upload:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -920,21 +920,10 @@ waterfall:upload:
       when: always
   before_script:
     - apk add --no-cache curl jq python3
-  script:
     - |
       curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
-      curl \
-        -X POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
-        "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-        -d '{"state":"success",
-              "target_url":"'"https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"'",
-              "description":"Perfetto trace available",
-              "context":"eic/perfetto-launcher"
-            }' ;
   variables:
     GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
   allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -909,7 +909,7 @@ waterfall:upload:
   before_script:
     - apk add --no-cache curl jq python3
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/9a8861f888ff948c8bc277562d4d81f3b8f2acd0/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/c0fa31d2a83ccbb63f44961aa68455aaf7902e86/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,7 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/9c480aa2bb603f0b34e44a3591006406aaa84af7/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/49120c9e467fee1d04da5c320a32d6b1f3e7e324/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,8 +59,8 @@ stages:
   - benchmarks
   - test
   - finalize
-  - status-report
   - waterfall
+  - status-report
 
 ## only run CI for in the following cases:
 ## master, stable branch, release tag, MR event and nightly builds
@@ -928,4 +928,4 @@ waterfall:upload:
   variables:
     GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
   when: always
-  allow_failure: true
+  allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -899,7 +899,7 @@ waterfall:upload:
   dependencies: []
   extends: .status
   variables:
-    STATUS: "success"
+    STATE: "success"
     STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
     STATUS_CONTEXT: "eic/perfetto-launcher"
     DESCRIPTION: "Perfetto trace available"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,6 +174,8 @@ version:
   rules:
     - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
   before_script: []
+  variables:
+    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
   script:
     - |
       curl \
@@ -182,7 +184,7 @@ version:
         -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
         "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
         -d '{"state":"'"${STATE}"'",
-              "target_url":"'"https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"'",
+              "target_url":"'"${STATUS_TARGET_URL}"'",
               "description":"'"${DESCRIPTION} $(TZ=America/New_York date)"'",
               "context":"eicweb/eic_container"
             }' ;
@@ -193,6 +195,8 @@ status:pending:
   variables:
     STATE: "pending"
     DESCRIPTION: "Started..."
+    # Trace doesn't exist yet during pending status; link to pipeline instead
+    STATUS_TARGET_URL: "${CI_PIPELINE_URL}"
   when: always
 
 ## base job settings for all docker interactions
@@ -918,9 +922,10 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/main/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/6afa43fc6642f8a89e960f8ff4ce40791b4713a1/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:
     GITHUB_PAGES_TOKEN: ${EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN}
   when: always
+  allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,7 @@ variables:
 
 stages:
   - status-pending
+  - waterfall
   - config
   - base            ## base OS image
   - eic             ## EIC container images
@@ -59,7 +60,6 @@ stages:
   - benchmarks
   - test
   - finalize
-  - waterfall
   - status-report
 
 ## only run CI for in the following cases:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,7 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/49120c9e467fee1d04da5c320a32d6b1f3e7e324/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/dca7667889182917fbef9881a53cf49493c1b561/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,7 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/6afa43fc6642f8a89e960f8ff4ce40791b4713a1/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/8b856e11e8b546b526a5b6b705c44ed5c12839a5/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,6 @@ variables:
 
 stages:
   - status-pending
-  - waterfall
   - config
   - base            ## base OS image
   - eic             ## EIC container images
@@ -60,6 +59,7 @@ stages:
   - benchmarks
   - test
   - finalize
+  - waterfall
   - status-report
 
 ## only run CI for in the following cases:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ stages:
   - test
   - finalize
   - status-report
+  - waterfall
 
 ## only run CI for in the following cases:
 ## master, stable branch, release tag, MR event and nightly builds
@@ -181,7 +182,7 @@ version:
         -H "Authorization: token ${GITHUB_REPO_STATUS_TOKEN}" \
         "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
         -d '{"state":"'"${STATE}"'",
-              "target_url":"'"${CI_PIPELINE_URL}"'",
+              "target_url":"'"https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"'",
               "description":"'"${DESCRIPTION} $(TZ=America/New_York date)"'",
               "context":"eicweb/eic_container"
             }' ;
@@ -907,3 +908,19 @@ status:failure:
     STATE: "failure"
     DESCRIPTION: "Failed!"
   when: on_failure
+
+waterfall:upload:
+  stage: waterfall
+  image: alpine:latest
+  rules:
+    - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
+  before_script:
+    - apk add --no-cache curl jq
+  script:
+    - |
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/main/waterfall-eicweb.sh \
+           -o waterfall-eicweb.sh
+      sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
+  variables:
+    GITHUB_PAGES_TOKEN: ${GITHUB_PAGES_TOKEN}
+  when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -909,7 +909,7 @@ waterfall:upload:
   before_script:
     - apk add --no-cache curl jq python3
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/c0fa31d2a83ccbb63f44961aa68455aaf7902e86/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/fb700e3eabbfee52561de4aae5062f11d8343b27/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,7 @@ version:
     - if: $GITHUB_SHA !~ /^$/ # when GITHUB_SHA non-empty
   before_script: []
   variables:
-    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
+    STATUS_TARGET_URL: "${CI_PIPELINE_URL}"
   script:
     - |
       curl \
@@ -195,8 +195,6 @@ status:pending:
   variables:
     STATE: "pending"
     DESCRIPTION: "Started..."
-    # Trace doesn't exist yet during pending status; link to pipeline instead
-    STATUS_TARGET_URL: "${CI_PIPELINE_URL}"
   when: always
 
 ## base job settings for all docker interactions
@@ -902,6 +900,7 @@ status:success:
   variables:
     STATE: "success"
     DESCRIPTION: "Succeeded!"
+    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
   when: on_success
 
 status:failure:
@@ -911,6 +910,7 @@ status:failure:
   variables:
     STATE: "failure"
     DESCRIPTION: "Failed!"
+    STATUS_TARGET_URL: "https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json"
   when: on_failure
 
 waterfall:upload:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,7 @@ waterfall:upload:
     - apk add --no-cache curl jq
   script:
     - |
-      curl -LfsS https://raw.githubusercontent.com/eic/snippets/28a328e21626b078a9de081ae92dca0255911c65/waterfall-eicweb.sh \
+      curl -LfsS https://raw.githubusercontent.com/eic/snippets/9c480aa2bb603f0b34e44a3591006406aaa84af7/waterfall-eicweb.sh \
            -o waterfall-eicweb.sh
       sh waterfall-eicweb.sh --pages ${CI_PROJECT_ID} ${CI_PIPELINE_ID}
   variables:


### PR DESCRIPTION
## Summary

Adds a `waterfall:upload` CI job that generates a Chrome trace JSON from the GitLab pipeline job timeline and uploads it to [eic/perfetto-launcher](https://eic.github.io/perfetto-launcher/), making pipeline timelines directly viewable in [Perfetto UI](https://ui.perfetto.dev). Example at https://eic.github.io/perfetto-launcher/?trace=traces%2Ftrace-143223.json .

The GitHub commit status `target_url` is overridden to point to the Perfetto launcher instead of the raw GitLab pipeline URL.

## Changes

### New stage: `waterfall`

Added before `status-report` so the upload completes before the final commit status is posted. `allow_failure: false` so a failed upload propagates to the pipeline result.

### New job: `waterfall:upload`

- Uses `alpine:latest` with `curl`, `python3`, and `jq`
- Downloads `waterfall-eicweb.sh` from `eic/snippets` at a pinned commit SHA
- Runs with `--pages` to upload `traces/trace-${CI_PIPELINE_ID}.json` to `eic/perfetto-launcher` via the GitHub Contents API
- Runs `when: always` (upload trace even when pipeline fails)
- Requires `EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN` CI/CD variable (`contents:write` on `eic/perfetto-launcher`)

### Override `.status` target URL

Override from default `${CI_PIPELINE_URL}` to the Perfetto launcher URL:

```
https://eic.github.io/perfetto-launcher/?trace=traces/trace-${CI_PIPELINE_ID}.json
```

The URL is pre-computable from `CI_PIPELINE_ID`. By the time a developer clicks the status link, the `waterfall:upload` job will have completed and the trace will be available. The `status:pending` job still uses `${CI_PIPELINE_URL}` (via `STATUS_TARGET_URL` override) since the trace does not exist yet when the pending status is posted.

## Required setup

Add a CI/CD variable `EIC_PERFETTO_LAUNCHER_GITHUB_PAGES_TOKEN` in the GitLab project settings with a GitHub PAT that has `contents:write` scope on the `eic/perfetto-launcher` repository.

## How it works

GitHub Pages cannot set `Access-Control-Allow-Origin` headers, so Perfetto cannot directly fetch trace files from it. The `eic/perfetto-launcher` site works around this: its `index.html` launcher fetches the trace same-origin (no CORS issue) and pushes it to Perfetto via the [postMessage PING/PONG protocol](https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui). The trace listing (`traces/index.json`) is generated at deploy time from git history by the [deploy workflow](https://github.com/eic/perfetto-launcher/blob/main/.github/workflows/deploy.yml) — it is not committed to the repository.