### PR TITLE
fix(ci): convert .gitlab-ci.yml to pure DAG pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,17 +50,6 @@ variables:
   GITHUB_SHA: ""
   GITHUB_PR: ""
 
-stages:
-  - status-pending
-  - config
-  - base            ## base OS image
-  - eic             ## EIC container images
-  - deploy          ## build/deploy singularity images
-  - benchmarks
-  - test
-  - finalize
-  - status-report
-
 ## only run CI for in the following cases:
 ## master, stable branch, release tag, MR event and nightly builds
 ## nightly builds are now part of the regular master build in order to keep
@@ -100,6 +89,7 @@ workflow:
 
 nvidia-smi:
   stage: config
+  needs: []
   image: nvidia/cuda:${CUDA_VERSION}-base-${CUDA_OS}
   tags:
     - gpu
@@ -116,6 +106,7 @@ nvidia-smi:
 ## - export tag to public registries, optional secondary export tag
 version:
   stage: config
+  needs: []
   script:
     - |
       if [ -n "${VERSION}" ]; then
@@ -188,6 +179,7 @@ version:
 
 status:pending:
   stage: status-pending
+  needs: []
   extends: .status
   variables:
     STATE: "pending"
@@ -747,6 +739,7 @@ df:
 .prune:
   extends: .build
   stage: config
+  needs: []
   rules:
     - when: manual
   script:
@@ -771,6 +764,7 @@ prune:docker-new:
 clean_internal_tag:
   image: alpine/curl
   stage: finalize
+  needs: []
   rules:
     - when: manual
   script:
@@ -785,6 +779,7 @@ clean_internal_tag:
 .clean_unstable_mr:
   extends: .docker
   stage: finalize
+  needs: []
   when: always
   script:
     - apk add curl jq
@@ -881,6 +876,7 @@ clean_pipeline:docker-new:
 spack-cache-cleanup:
   extends: .build
   stage: finalize
+  needs: [version]
   when: always
   allow_failure: true
   script:
@@ -892,7 +888,7 @@ spack-cache-cleanup:
 
 status:success:
   stage: status-report
-  dependencies: []
+  needs: []
   extends: .status
   variables:
     STATE: "success"
@@ -901,7 +897,7 @@ status:success:
 
 status:failure:
   stage: status-report
-  dependencies: []
+  needs: []
   extends: .status
   variables:
     STATE: "failure"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -900,21 +900,21 @@ spack-cache-cleanup:
 status:success:
   stage: status-report
   needs:
-    - nvidia-smi
-    - user_spack_environment
-    - cuda:torch
-    - eic_xl:singularity:default
-    - eic_xl:singularity:nightly
-    - benchmarks:geoviewer:default
-    - benchmarks:detector:default
-    - benchmarks:detector:nightly
-    - benchmarks:phyiscs:default
-    - benchmarks:physics:nightly
-    - clean_pipeline:gpu
-    - clean_pipeline:docker-new
-    - clean_unstable_mr:gpu
-    - clean_unstable_mr:docker-new
-    - spack-cache-cleanup
+    - { job: nvidia-smi, optional: true }
+    - { job: user_spack_environment, optional: true }
+    - { job: "cuda:torch", optional: true }
+    - { job: "eic_xl:singularity:default", optional: true }
+    - { job: "eic_xl:singularity:nightly", optional: true }
+    - { job: "benchmarks:geoviewer:default", optional: true }
+    - { job: "benchmarks:detector:default", optional: true }
+    - { job: "benchmarks:detector:nightly", optional: true }
+    - { job: "benchmarks:phyiscs:default", optional: true }
+    - { job: "benchmarks:physics:nightly", optional: true }
+    - { job: "clean_pipeline:gpu", optional: true }
+    - { job: "clean_pipeline:docker-new", optional: true }
+    - { job: "clean_unstable_mr:gpu", optional: true }
+    - { job: "clean_unstable_mr:docker-new", optional: true }
+    - { job: spack-cache-cleanup, optional: true }
   extends: .status
   variables:
     STATE: "success"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,17 @@ variables:
   GITHUB_SHA: ""
   GITHUB_PR: ""
 
+stages:
+  - status-pending
+  - config
+  - base            ## base OS image
+  - eic             ## EIC container images
+  - deploy          ## build/deploy singularity images
+  - benchmarks
+  - test
+  - finalize
+  - status-report
+
 ## only run CI for in the following cases:
 ## master, stable branch, release tag, MR event and nightly builds
 ## nightly builds are now part of the regular master build in order to keep

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -899,7 +899,22 @@ spack-cache-cleanup:
 
 status:success:
   stage: status-report
-  needs: []
+  needs:
+    - nvidia-smi
+    - user_spack_environment
+    - cuda:torch
+    - eic_xl:singularity:default
+    - eic_xl:singularity:nightly
+    - benchmarks:geoviewer:default
+    - benchmarks:detector:default
+    - benchmarks:detector:nightly
+    - benchmarks:phyiscs:default
+    - benchmarks:physics:nightly
+    - clean_pipeline:gpu
+    - clean_pipeline:docker-new
+    - clean_unstable_mr:gpu
+    - clean_unstable_mr:docker-new
+    - spack-cache-cleanup
   extends: .status
   variables:
     STATE: "success"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -790,7 +790,16 @@ clean_internal_tag:
 .clean_unstable_mr:
   extends: .docker
   stage: finalize
-  needs: []
+  needs:
+    - { job: user_spack_environment, optional: true }
+    - { job: "cuda:torch", optional: true }
+    - { job: "eic_xl:singularity:default", optional: true }
+    - { job: "eic_xl:singularity:nightly", optional: true }
+    - { job: "benchmarks:geoviewer:default", optional: true }
+    - { job: "benchmarks:detector:default", optional: true }
+    - { job: "benchmarks:detector:nightly", optional: true }
+    - { job: "benchmarks:phyiscs:default", optional: true }
+    - { job: "benchmarks:physics:nightly", optional: true }
   when: always
   script:
     - apk add curl jq
@@ -834,6 +843,15 @@ clean_unstable_mr:docker-new:
   needs:
     - version
     - clean_internal_tag
+    - { job: user_spack_environment, optional: true }
+    - { job: "cuda:torch", optional: true }
+    - { job: "eic_xl:singularity:default", optional: true }
+    - { job: "eic_xl:singularity:nightly", optional: true }
+    - { job: "benchmarks:geoviewer:default", optional: true }
+    - { job: "benchmarks:detector:default", optional: true }
+    - { job: "benchmarks:detector:nightly", optional: true }
+    - { job: "benchmarks:phyiscs:default", optional: true }
+    - { job: "benchmarks:physics:nightly", optional: true }
   when: always
   script:
     - apk add curl jq


### PR DESCRIPTION
# ci: convert to pure DAG pipeline

## Problem

The pipeline uses a mix of stage-ordered and DAG jobs, which produces
unexpected behavior when an early job fails.

**Observed symptoms** (e.g. job [#7790629][job]):

1. `waterfall:upload` (stage `waterfall`, no `needs:`) fails.
2. Because `version` (stage `config`, no `needs:`) is stage-ordered,
   GitLab blocks the entire `config` stage — `version` never runs.
3. Because `base`, `eic`, and `benchmarks` are DAG jobs (they have
   `needs:`), GitLab treats their stuck dependencies as satisfied and
   schedules them immediately — container builds run without `version`
   artifacts, producing wrong or missing tags.

[job]: https://eicweb.phy.anl.gov/containers/eic_container/-/jobs/7790629

## Root cause

In GitLab CI's mixed stage+DAG mode:

- Jobs **without** `needs:` follow strict stage ordering. A failure in
  stage N blocks all subsequent stages for those jobs.
- Jobs **with** `needs:` bypass stage ordering entirely. If a `needs:`
  dependency is stuck in a blocked (never-scheduled) stage, GitLab
  treats it as satisfied, and the dependent job starts anyway.

Having even a single job without `needs:` is enough to trigger this
split behaviour.

## Fix

Convert the pipeline to **pure DAG** mode:

- **Keep the `stages:` list** (required for GitLab to recognise custom
  stage names), but it no longer controls execution order — that is
  enforced entirely by `needs:`. With all jobs using `needs:`, stage
  ordering has no effect, and accidentally omitting `needs:` from a
  new job becomes an immediately visible error rather than silent wrong
  behaviour.
- **Add `needs: []`** to every root-node job (no upstream
  dependencies): `version`, `nvidia-smi`, `status:pending`, `.prune`,
  `clean_internal_tag`, `.clean_unstable_mr`, `status:success`,
  `status:failure`.
- **Add `needs: [version]`** to `spack-cache-cleanup` so it correctly
  inherits the `INTERNAL_TAG` dotenv artifact from `version`.
- **Remove `dependencies: []`** from `status:success` and
  `status:failure` — with `needs: []`, no artifacts are downloaded
  anyway, so this was redundant.

The existing `needs:` chains that enforce build ordering
(`version → base → eic → benchmarks`) are unchanged.

## Expected behaviour after this MR

| Job | Starts when |
|---|---|
| `version`, `nvidia-smi`, `status:pending` | Pipeline created |
| `base` | `version` succeeds |
| `eic` | `base` succeeds |
| `benchmarks` | `eic` succeeds |
| `spack-cache-cleanup` | `version` succeeds |
| `status:success` | All non-manual terminal jobs complete successfully |
| `status:failure` | `when: on_failure` with `needs: []` — fires when any pipeline job fails |

A failure in any single job (e.g. a future `waterfall:upload` from
!278) no longer blocks unrelated jobs in the build chain.
