### PR TITLE
feat: eic_{ci,xl}: add pelican ~server

### DIFF
--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -38,6 +38,7 @@ spack:
   - ollama
   - onnx
   - osg-ca-certs
+  - pelican
   - podio
   - prmon
   - pythia8

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -370,6 +370,7 @@ packages:
     - build_system=autotools
   pelican:
     require:
+    - '@7.24.3:'
     - ~server
   phonebook-cli:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -368,6 +368,9 @@ packages:
     require:
     # FIXME julia requires libpcre2-8.so, but shared lib is only built by autotools
     - build_system=autotools
+  pelican:
+    require:
+    - ~server
   phonebook-cli:
     require:
     - '@1.0.0'

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -70,6 +70,7 @@ spack:
   - onnx
   - opencascade
   - osg-ca-certs
+  - pelican
   - phonebook-cli
   - podio
   - poppler

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -23,6 +23,7 @@ bd32638d817fa66188880e557196acd2a5d6e7b6
 b17f3abec760256ad7faf1b1d102f2553d6a3622
 45f50975f023b3a444217e3d474c2b2d264763b3
 6b86b44735775c97636861dd66ee14ce83906422
+7f9f7ff5c232068aec8ff30b147a098dd25d9ef9
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -43,3 +44,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## b17f3abec760256ad7faf1b1d102f2553d6a3622: (py-)protobuf: add v(5.)28.3
 ## 45f50975f023b3a444217e3d474c2b2d264763b3: py-torch: patch for GCC-14.2 ICE on aarch64
 ## 6b86b44735775c97636861dd66ee14ce83906422: apfelxx, epic, partons*, sfml: new packages
+## 7f9f7ff5c232068aec8ff30b147a098dd25d9ef9: pelican: new package, v7.24.3


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds `pelican` (client only, no server) to eic_ci and eic_xl. This should allow us to avoid the download step in https://eicweb.phy.anl.gov/EIC/benchmarks/detector_benchmarks/-/jobs/7679744.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: pelican for OSDF)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
