### PR TITLE
feat: eic_{ci,xl}: add py-snakemake-storage-plugin-pelican

### DIFF
--- a/spack-environment/ci/spack.yaml
+++ b/spack-environment/ci/spack.yaml
@@ -70,6 +70,9 @@ spack:
   - py-rucio-clients
   - py-scipy
   - py-seaborn
+  - py-snakemake-storage-plugin-fs
+  - py-snakemake-storage-plugin-pelican
+  - py-snakemake-storage-plugin-rucio
   - py-toml
   - py-uproot
   - py-vector

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -595,6 +595,9 @@ packages:
   py-snakemake-storage-plugin-http:
     require:
     - '@0.2.3:'
+  py-snakemake-storage-plugin-pelican:
+    require:
+    - '@0.1.1:'
   py-snakemake-storage-plugin-rucio:
     require:
     - '@0.4.1:'

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -116,6 +116,7 @@ spack:
   - py-snakemake-executor-plugin-slurm
   - py-snakemake-executor-plugin-slurm-jobstep
   - py-snakemake-storage-plugin-fs
+  - py-snakemake-storage-plugin-pelican
   - py-snakemake-storage-plugin-rucio
   - py-toml
   - py-torch

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -27,6 +27,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 346babf5aebcf03045fbe10e59750fac8c95947f
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
+045873c8cbce3eef07ed068a998467e01bd91129
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -51,3 +52,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 346babf5aebcf03045fbe10e59750fac8c95947f: py-mplhep(-data): add new versions
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
+## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds the `py-snakemake-storage-plugin-pelican` storage plugin for pelican. This may allow validation to write to pelican data federations for cache or storage.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: pelican for OSDF)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
