### PR TITLE
fix: inject target=all into external llvm spec

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -286,6 +286,8 @@ spack compiler find --scope spack
 #    consistently invoke the correct archive tool.
 # Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
 yq -iy '.packages.gcc.externals[].extra_attributes += {"environment": {"set": {"GCC_AR": "gcc-ar"}}}' ${SPACK_ROOT}/etc/spack/packages.yaml
+# Ensure LLVM externals satisfy iwyu variant requirements (targets=all)
+yq -iy '.packages.llvm.externals[].spec += " targets=all"' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame compilers
 spack config blame packages
 EOF


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes a significant container size regression where we ended up install `llvm` in duplicate. The chain of events goes like this:
1. the debian base is used and gcc, llvm are installed,
2. spack registers both gcc and llvm as external compilers, but due to limitations on how the detection of the compilers works, not all variants are added; in particular we add `llvm+clang` without `targets=x86` or `targets=aarch64`,
3. iwyu is added to the ci and xl environments (and a bunch of others),
4. in concretization, iwyu requires `llvm+clang targets=all` or `llvm+clang targets=x86`, which aren't satisfied by the external `llvm+clang`,
5. a new llvm is built to satisfy iwyu, in the `xl/spack.yaml` layer,
6. in concretization of the `xl/epic/spack.yaml` layer, spack can choose between two external compilers or the one it built itself, and spack prefers the self-built one,
7. simultaneously, `algorithms`, `eicrecon`, and `edm4eic` are solved together since they are part of the same dependnecy chain, and for reasons of limiting compiler mixing end up picking the external gcc compiler used for their dependencies.

Ultimately this results in the extra llvm being added.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: extra llvm taking up space)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Urgency since we want to backport this to 2026.05.1 as a hotfix.