### PR TITLE
feat: build ROOT against external llvm

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -119,7 +119,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libllvm${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev llvm${CLANG}-dev
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -119,7 +119,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libllvm${CLANG}-dev
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -119,7 +119,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev llvm${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libedit-dev llvm${CLANG}-dev
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -120,7 +120,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libllvm${CLANG}-dev
 if [ "${CLANG#-}" -ge 20 ]; then apt-get -yqq install flang${CLANG}; fi
 apt-get -yqq autoremove
 # Remove symlinks loop observed in nvidia/cuda devel images

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -120,7 +120,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev llvm${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libedit-dev llvm${CLANG}-dev
 if [ "${CLANG#-}" -ge 20 ]; then apt-get -yqq install flang${CLANG}; fi
 apt-get -yqq autoremove
 # Remove symlinks loop observed in nvidia/cuda devel images

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -261,7 +261,6 @@ declare -A target=(
 target=${target[${TARGETPLATFORM}]}
 spack config --scope spack add "packages:all:require:[target=${target}]"
 spack config --scope spack add "packages:all:target:[${target}]"
-spack config blame packages
 mkdir -p $HOME/.spack/  # workaround for Spack not creating config directory automatically in some versions (see https://github.com/spack/spack/issues/51564)
 spack config --scope user add "config:suppress_gpg_warnings:true"
 spack config --scope user add "config:build_jobs:${jobs}"
@@ -270,29 +269,6 @@ spack config --scope user add "config:source_cache:/var/cache/spack"
 spack config --scope user add "config:install_tree:root:/opt/software"
 spack config --scope user add "config:ccache:true"
 spack config blame config
-spack compiler find --scope spack
-# Ensure GCC externals have LTO‑safe binutils configured.
-#
-# 1. LTO issue being worked around:
-#    When GCC is built/used with LTO support, archive creation for objects
-#    that may contain LTO bytecode must use the plugin‑aware wrappers
-#    (gcc-ar/gcc-ranlib) instead of the system "ar"/"ranlib".  If plain "ar"
-#    is used, link steps can fail with LTO plugin errors or produce archives
-#    that cannot be linked correctly.
-#
-# 2. Why GCC_AR must be set in Spack's external configuration:
-#    Spack discovers the system GCC as an "external" compiler and records it
-#    in packages.yaml/compilers.yaml.  However, Spack does not automatically
-#    export GCC_AR to all build environments for that external GCC.  By
-#    adding extra_attributes.environment.set.GCC_AR here, we force Spack to
-#    set GCC_AR=gcc-ar whenever it uses this external GCC, so that LTO builds
-#    consistently invoke the correct archive tool.
-# Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
-yq -iy '.packages.gcc.externals[].extra_attributes += {"environment": {"set": {"GCC_AR": "gcc-ar"}}}' ${SPACK_ROOT}/etc/spack/packages.yaml
-# Ensure LLVM externals satisfy iwyu variant requirements (targets=all)
-yq -iy '.packages.llvm.externals[].spec += " targets=all"' ${SPACK_ROOT}/etc/spack/packages.yaml
-spack config blame compilers
-spack config blame packages
 EOF
 
 ## Bootstrap
@@ -306,6 +282,7 @@ EOF
 ## - allow llvm to be buildable for py-numba > py-llvmlite
 RUN <<EOF
 set -e
+spack compiler find --scope spack
 spack external find --scope spack llvm
 spack external find --scope spack --not-buildable gcc
 spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cuda
@@ -313,6 +290,50 @@ spack external find --scope spack --not-buildable --path /usr/local/cuda/bin cud
 # the +allow-unsupported-compilers variant disables the build-system conflict check.
 # Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
 yq -iy 'if .packages.cuda.externals then .packages.cuda.externals[].spec += " +allow-unsupported-compilers" else . end' ${SPACK_ROOT}/etc/spack/packages.yaml
+# Ensure discovered GCC externals have LTO-safe binutils configured.
+#
+# 1. LTO issue being worked around:
+#    When GCC is built/used with LTO support, archive creation for objects
+#    that may contain LTO bytecode must use the plugin-aware wrappers
+#    (gcc-ar/gcc-ranlib) instead of the system "ar"/"ranlib". If plain "ar"
+#    is used, link steps can fail with LTO plugin errors or produce archives
+#    that cannot be linked correctly.
+#
+# 2. Why GCC_AR must be set in Spack's external configuration:
+#    Spack records the system GCC as an external in packages.yaml, but does not
+#    automatically export GCC_AR for builds that use it. Adding
+#    extra_attributes.environment.set.GCC_AR here ensures LTO-enabled builds
+#    consistently invoke the correct archive tool.
+# Note: this uses the python-based yq. Future base image upgrades may cause syntax change.
+yq -iy '.packages.gcc.externals[] |= (
+  .extra_attributes += {
+    "environment": {
+      "set": {
+        "GCC_AR": "gcc-ar"
+      }
+    }
+  }
+)' ${SPACK_ROOT}/etc/spack/packages.yaml
+# Ensure discovered LLVM externals satisfy iwyu requirements and export the
+# CMake hints ROOT/cling expects when using the system LLVM.
+export LLVM_PREFIX=$(llvm-config --prefix)
+export LLVM_BIN=$(llvm-config --bindir)
+yq -iy '.packages.llvm.externals[] |= (
+  .spec += " targets=all" |
+  .extra_attributes += {
+    "environment": {
+      "set": {
+        "LLVM_DIR": "\(env.LLVM_PREFIX)/lib/cmake/llvm",
+        "LLVM_TOOLS_BINARY_DIR": env.LLVM_BIN,
+        "LLVM_TABLEGEN": "\(env.LLVM_BIN)/llvm-tblgen",
+        "LLVM_TABLEGEN_EXE": "\(env.LLVM_BIN)/llvm-tblgen"
+      },
+      "prepend_path": {
+        "CMAKE_PREFIX_PATH": env.LLVM_PREFIX
+      }
+    }
+  }
+)' ${SPACK_ROOT}/etc/spack/packages.yaml
 spack config blame packages
 EOF
 

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -120,7 +120,7 @@ fi
 # Install packages
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
-apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev libllvm${CLANG}-dev
+apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev llvm${CLANG}-dev
 if [ "${CLANG#-}" -ge 20 ]; then apt-get -yqq install flang${CLANG}; fi
 apt-get -yqq autoremove
 # Remove symlinks loop observed in nvidia/cuda devel images

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -571,7 +571,7 @@ packages:
   root:
     require:
     - '@6.38.00'
-    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
+    - cxxstd=20 ~builtin_llvm +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
   sherpa:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -642,7 +642,7 @@ packages:
   root:
     require:
     - '@6.38.04'
-    - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
+    - cxxstd=20 ~builtin_llvm +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
   sherpa:
     require:

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -28,6 +28,7 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
+8cd9959e3fd4e54d79bbf75210e335ab842e1af0
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -53,3 +54,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
+## 8cd9959e3fd4e54d79bbf75210e335ab842e1af0: root: add builtin_llvm variant to allow external LLVM

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -28,6 +28,10 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96
 107eb9966c8a9688e042c42e903274099688b590
 045873c8cbce3eef07ed068a998467e01bd91129
+30e69adca31b9ba98e61c42b4126188911e3537c
+93acd58e1399d787dac69d61ecbbd1695c8a2bac
+056c2efcd8f3cceb629f9b78acbdf4533e008206
+ad4b252d254d49db587abd6fd06c375c71d27a01
 8cd9959e3fd4e54d79bbf75210e335ab842e1af0
 ---
 ## Optional hash table with comma-separated file list
@@ -54,4 +58,8 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 2c49a2c6a2f8a95c25e0add0e8fc67d1a5351f96: py-awkward, py-uproot, py-uhi ecosystem (HEP): add new versions
 ## 107eb9966c8a9688e042c42e903274099688b590: dd4hep: add v1.36
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
+## 30e69adca31b9ba98e61c42b4126188911e3537c: root: cleanup recipe since the minimum version is 6.28.00
+## 93acd58e1399d787dac69d61ecbbd1695c8a2bac: Miscellaneous package fixes
+## 056c2efcd8f3cceb629f9b78acbdf4533e008206: root: require openblas ~ilp64 symbol_suffix=none when ^openblas
+## ad4b252d254d49db587abd6fd06c375c71d27a01: root: add v6.36.12
 ## 8cd9959e3fd4e54d79bbf75210e335ab842e1af0: root: add builtin_llvm variant to allow external LLVM

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -30,7 +30,6 @@ b17f3abec760256ad7faf1b1d102f2553d6a3622
 045873c8cbce3eef07ed068a998467e01bd91129
 30e69adca31b9ba98e61c42b4126188911e3537c
 93acd58e1399d787dac69d61ecbbd1695c8a2bac
-056c2efcd8f3cceb629f9b78acbdf4533e008206
 ad4b252d254d49db587abd6fd06c375c71d27a01
 8cd9959e3fd4e54d79bbf75210e335ab842e1af0
 ---
@@ -60,6 +59,5 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 045873c8cbce3eef07ed068a998467e01bd91129: py-snakemake-storage-plugin-pelican: new package v0.1.1 + deps
 ## 30e69adca31b9ba98e61c42b4126188911e3537c: root: cleanup recipe since the minimum version is 6.28.00
 ## 93acd58e1399d787dac69d61ecbbd1695c8a2bac: Miscellaneous package fixes
-## 056c2efcd8f3cceb629f9b78acbdf4533e008206: root: require openblas ~ilp64 symbol_suffix=none when ^openblas
 ## ad4b252d254d49db587abd6fd06c375c71d27a01: root: add v6.36.12
 ## 8cd9959e3fd4e54d79bbf75210e335ab842e1af0: root: add builtin_llvm variant to allow external LLVM

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -26,6 +26,7 @@ caf013be0ee1594fdbba8feb07ffecc88474a2b0
 acac89d6bb7079412e711a50a3f06681132a2723
 438abd1e09f0cea9cb0ccc7e0326adcd0408196b
 4dc856a13e9066ca3249a593d351af8cda521fa3
+e41e172d579e30881556873fe32f8408f6647800
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -49,3 +50,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## acac89d6bb7079412e711a50a3f06681132a2723: cuda: append --allow-unsupported-compiler to CUDAFLAGS for dependent_spec
 ## 438abd1e09f0cea9cb0ccc7e0326adcd0408196b: herwig3: add CT14(?n)lo pdfsets as build-time resources
 ## 4dc856a13e9066ca3249a593d351af8cda521fa3: root: add v6.40.00, v6.40.02
+$$ e41e172d579e30881556873fe32f8408f6647800: root: allow ~builtin_llvm with 6.40 and newer

--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -50,4 +50,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## acac89d6bb7079412e711a50a3f06681132a2723: cuda: append --allow-unsupported-compiler to CUDAFLAGS for dependent_spec
 ## 438abd1e09f0cea9cb0ccc7e0326adcd0408196b: herwig3: add CT14(?n)lo pdfsets as build-time resources
 ## 4dc856a13e9066ca3249a593d351af8cda521fa3: root: add v6.40.00, v6.40.02
-$$ e41e172d579e30881556873fe32f8408f6647800: root: allow ~builtin_llvm with 6.40 and newer
+## e41e172d579e30881556873fe32f8408f6647800: root: allow ~builtin_llvm with 6.40 and newer


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
ROOT includes its version of llvm, but it should be possible to build against an external llvm. With ROOT 6.36, that external llvm is at the same level as what ROOT requires. This PR enables the external llvm build.

Needs:
- [ ] https://github.com/eic/eic-spack/pull/932
- [x] #298

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: ROOT with external llvm)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
