### PR TITLE
feat: pass GITHUB_SPACK_TOKEN secret for access private repos

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -541,7 +541,7 @@ jobs:
             "CI_REGISTRY_PASSWORD=${{ secrets.GHCR_REGISTRY_TOKEN }}"
             "GITHUB_REGISTRY_USER=${{ secrets.GHCR_REGISTRY_USER }}"
             "GITHUB_REGISTRY_TOKEN=${{ secrets.GHCR_REGISTRY_TOKEN }}"
-            "SPACK_GITHUB_TOKEN=${{ secrets.SPACK_GITHUB_TOKEN }}"
+            "GITHUB_SPACK_TOKEN=${{ secrets.SPACK_GITHUB_TOKEN }}"
           secret-files: |
             mirrors=mirrors.yaml
           platforms: ${{ matrix.PLATFORM }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -541,7 +541,7 @@ jobs:
             "CI_REGISTRY_PASSWORD=${{ secrets.GHCR_REGISTRY_TOKEN }}"
             "GITHUB_REGISTRY_USER=${{ secrets.GHCR_REGISTRY_USER }}"
             "GITHUB_REGISTRY_TOKEN=${{ secrets.GHCR_REGISTRY_TOKEN }}"
-            "GITHUB_SPACK_TOKEN=${{ secrets.GITHUB_SPACK_TOKEN }}"
+            "SPACK_GITHUB_TOKEN=${{ secrets.SPACK_GITHUB_TOKEN }}"
           secret-files: |
             mirrors=mirrors.yaml
           platforms: ${{ matrix.PLATFORM }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -541,6 +541,7 @@ jobs:
             "CI_REGISTRY_PASSWORD=${{ secrets.GHCR_REGISTRY_TOKEN }}"
             "GITHUB_REGISTRY_USER=${{ secrets.GHCR_REGISTRY_USER }}"
             "GITHUB_REGISTRY_TOKEN=${{ secrets.GHCR_REGISTRY_TOKEN }}"
+            "GITHUB_SPACK_TOKEN=${{ secrets.GITHUB_SPACK_TOKEN }}"
           secret-files: |
             mirrors=mirrors.yaml
           platforms: ${{ matrix.PLATFORM }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -500,6 +500,7 @@ eic:
                    --secret type=env,id=CI_REGISTRY_PASSWORD,env=CI_REGISTRY_PASSWORD
                    --secret type=env,id=GITHUB_REGISTRY_USER,env=GITHUB_REGISTRY_USER
                    --secret type=env,id=GITHUB_REGISTRY_TOKEN,env=GITHUB_REGISTRY_TOKEN
+                   --secret type=env,id=GITHUB_SPACK_TOKEN,env=GITHUB_SPACK_TOKEN
                    --provenance false
                    containers/eic
                    2>&1 | tee build.log

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -99,11 +99,18 @@ RUN --mount=type=cache,target=/ccache,id=ccache-${TARGETPLATFORM}              \
     --mount=type=secret,id=CI_REGISTRY_PASSWORD,env=CI_REGISTRY_PASSWORD \
     --mount=type=secret,id=GITHUB_REGISTRY_USER,env=GITHUB_REGISTRY_USER \
     --mount=type=secret,id=GITHUB_REGISTRY_TOKEN,env=GITHUB_REGISTRY_TOKEN \
+    --mount=type=secret,id=GITHUB_SPACK_TOKEN                           \
     <<EOF
 set -e
+if [ -s /run/secrets/GITHUB_SPACK_TOKEN ]; then
+  printf 'machine github.com login x-access-token password %s\n' \
+    "$(cat /run/secrets/GITHUB_SPACK_TOKEN)" > ~/.netrc
+  chmod 600 ~/.netrc
+fi
 export CCACHE_DIR=/ccache
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
 spack clean --downloads --stage
+rm -f ~/.netrc
 ccache --show-stats
 ccache --zero-stats
 EOF
@@ -242,12 +249,19 @@ RUN --mount=type=cache,target=/ccache,id=ccache-${TARGETPLATFORM}              \
     --mount=type=secret,id=CI_REGISTRY_PASSWORD,env=CI_REGISTRY_PASSWORD \
     --mount=type=secret,id=GITHUB_REGISTRY_USER,env=GITHUB_REGISTRY_USER \
     --mount=type=secret,id=GITHUB_REGISTRY_TOKEN,env=GITHUB_REGISTRY_TOKEN \
+    --mount=type=secret,id=GITHUB_SPACK_TOKEN                           \
     <<EOF
 set -e
+if [ -s /run/secrets/GITHUB_SPACK_TOKEN ]; then
+  printf 'machine github.com login x-access-token password %s\n' \
+    "$(cat /run/secrets/GITHUB_SPACK_TOKEN)" > ~/.netrc
+  chmod 600 ~/.netrc
+fi
 export CCACHE_DIR=/ccache
 spack ${SPACK_FLAGS} install ${SPACK_INSTALL_FLAGS}
 spack clean --downloads --stage
 spack gc --yes-to-all go go-bootstrap rust rust-bootstrap py-setuptools-rust py-maturin
+rm -f ~/.netrc
 ccache --show-stats
 ccache --zero-stats
 EOF

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="ce2dc68e4f75299f7a684708788870282ecde53a"
+EICSPACK_VERSION="45f676694035d99722fb3f89423ff94329c4df2b"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -111,10 +111,10 @@ packages:
     - '@10bbcdbf2be3ad3aa56febcf4c7662d771460a99'
   dawn:
     require:
-    - '@3_91a'
+    - '@main'
   dawncut:
     require:
-    - '@1_54a'
+    - '@main'
   dbus:
     require:
     # Until 1.15.12, https://gitlab.freedesktop.org/dbus/dbus/-/commit/b104667bd7ec55dda057ff4ffdde848336f253f4,


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds the capability to download from private GitHub repositories (https://github.com/eic/dawn, https://github.com/eic/dawncut). This allows us to add some bug fixes there to make the dawn views in https://github.com/eic/epic to work again.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: installation from private repositories)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
