### PR TITLE
feat: add glibc hwcaps multi-arch support

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="f767991330f68f3ff194be8df0ea213d16912ca9"
+EICSPACK_VERSION="ab13585e90e3009b55e5d49dc7428a4d2ff78311"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="ce2dc68e4f75299f7a684708788870282ecde53a"
+EICSPACK_VERSION="f767991330f68f3ff194be8df0ea213d16912ca9"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="84978bfb1ba00f2da4d86f7960a88ccbcb242eff"
+EICSPACK_VERSION="1f3d9fbd33707d8d39dfd4965c093772d6aadbfa"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="ab13585e90e3009b55e5d49dc7428a4d2ff78311"
+EICSPACK_VERSION="e205f238ccca722322edb6786f0716ab9697a411"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="e205f238ccca722322edb6786f0716ab9697a411"
+EICSPACK_VERSION="84978bfb1ba00f2da4d86f7960a88ccbcb242eff"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -94,6 +94,7 @@ packages:
     require:
     - '@2.4.7.1'
     - cxxstd=20
+    - hwcaps=x86_64_v3
   cli11:
     require:
     - '@2.4.2:'
@@ -179,6 +180,7 @@ packages:
     require:
     - '@3.5.0'
     - plugins=cxx
+    - hwcaps=x86_64_v3
   fjcontrib:
     require:
     - '@1.051'
@@ -303,6 +305,7 @@ packages:
     require:
     - '@6.5.5'
     - +python
+    - hwcaps=x86_64_v3
   #llvm:
     #require:
     #- any_of: [~gold, '@:']
@@ -635,6 +638,7 @@ packages:
   vecgeom:
     require:
     - '@2'
+    - hwcaps=x86_64_v3
   xerces-c:
     require:
     - cxxstd=20

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -94,7 +94,8 @@ packages:
     require:
     - '@2.4.7.1'
     - cxxstd=20
-    - hwcaps=x86_64_v3
+    - spec: hwcaps=x86_64_v3
+      when: target=x86_64_v2
   cli11:
     require:
     - '@2.4.2:'
@@ -180,7 +181,8 @@ packages:
     require:
     - '@3.5.0'
     - plugins=cxx
-    - hwcaps=x86_64_v3
+    - spec: hwcaps=x86_64_v3
+      when: target=x86_64_v2
   fjcontrib:
     require:
     - '@1.051'
@@ -305,7 +307,8 @@ packages:
     require:
     - '@6.5.5'
     - +python
-    - hwcaps=x86_64_v3
+    - spec: hwcaps=x86_64_v3
+      when: target=x86_64_v2
   #llvm:
     #require:
     #- any_of: [~gold, '@:']
@@ -638,7 +641,8 @@ packages:
   vecgeom:
     require:
     - '@2'
-    - hwcaps=x86_64_v3
+    - spec: hwcaps=x86_64_v3
+      when: target=x86_64_v2
   xerces-c:
     require:
     - cxxstd=20


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR picks up the experimental functionality in https://github.com/eic/eic-spack/pull/933 that adds glibc hwcaps runtime dispatch support to select libraries (clhep, fastjet, lhapdf, vecgeom).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: glibc hwcaps runtime dispatch)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
