### PR TITLE
chore: npsim-1.5.2

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="f56f48eeb7c4b2c286962ab4d7048d821bc35c6f"
+EICSPACK_VERSION="34c17311e8cc4a2008f949e889cbebb9041093b5"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -329,7 +329,7 @@ packages:
     - '@0.0.3'
   npsim:
     require:
-    - '@1.4.7'
+    - '@1.5.2'
     - +http
     - any_of: [+geocad, -geocad]
   ollama:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR upgrades `npsim` to v1.5.2. This also bumps eic-spack to include the follwing:
- 34c1731 npsim: add v1.5.2 (#941)
- 5a8cd76 eicrecon: add 1.38.0
- 1f930e3 epic: add 26.06.0
- ab36293 ci: make buildcache index update non-fatal (#921)
- b219d99 root: patch for tessellated closure checks after initialization (#948)
- bd91c4a Remove Spack v1 builtin import fallbacks from overlay packages (#944)
- 9d87025 root: patch to ensure GIL is held during CPython API call (#943)
- 0a37669 jana2: disable unit tests up to 2026.02.00 (#942)
- 480a795 fix(ci): run check-new-versions in spack-noble:develop (#922)
- 9eaf525 fix: correct JANA2 patch SHA256 for 2026.02.00 (#935)
- c5a5c4b fjcontrib: patch Centauro plugin for Euclidean distance and NNFJN2Plain (#936)
- d2ba223 jana2: add patch for ROOT 6.40 in 2026.02.00 (#931)
- 1569098 build(deps): bump actions/github-script from 8 to 9 (#926)

This therefore also includes the patch part of #300.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: npsim-1.5.2)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
