### PR TITLE
fix: spack: fix: install missing upstream packages in local store

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -530,7 +530,7 @@ user_spack_environment:
     - spack add edm4eic@git.main cxxstd=20
     - spack concretize
     - spack install --only dependencies edm4eic
-    - ls -al /opt/software/linux-*/compiler-wrapper-1.0-*/libexec/spack/gcc/g++
+    - ls -al $HOME/spack/linux-*/compiler-wrapper-1.0-*/libexec/spack/gcc/g++
     - spack install --verbose
     - ls $HOME/spack/
 

--- a/spack.sh
+++ b/spack.sh
@@ -15,6 +15,7 @@ a462612b64e97fa7dfe461c32c58553fd6ec63c5
 292b0dcaba3b2a5e3f9668d205d39fee2c715721
 d55f9abacc4e153d43a4c8bff81a383ba2f311f5
 678e506a95b319c573ba7e84703b06d7275ab80e
+52bef0e63711a0b63816b3f4b1561df5b158db65
 ---
 ## Optional hash table with comma-separated file list
 read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
@@ -27,3 +28,4 @@ read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
 ## 292b0dcaba3b2a5e3f9668d205d39fee2c715721: fix: write created time field with OCI buildcache config
 ## d55f9abacc4e153d43a4c8bff81a383ba2f311f5: views: collapse unique subtrees in symlink case
 ## 678e506a95b319c573ba7e84703b06d7275ab80e: fix: don't map prefix to view root for pkgs excluded from view
+## 52bef0e63711a0b63816b3f4b1561df5b158db65: fix: install missing upstream packages in local store


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR is an upstream fix that intends to fix #151. Instead of trying to install to the upstream prefix, install to the local store.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #151)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
