### PR TITLE
feat: use DD4hep G4HepEm plugin in npsim

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="9cb75284f136ce8cf9bc54fe5b979e40e6eba485"
+EICSPACK_VERSION="3f8e52f5790f29576b5a4699c3e7ae16d351b4d7"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="3f8e52f5790f29576b5a4699c3e7ae16d351b4d7"
+EICSPACK_VERSION="a4a400df716c92e034e564e2427626a430eb06cb"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -36,7 +36,7 @@ packages:
   acts:
     require:
     - '@45.3.0'
-    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +root +pr4496 +pr4502 +pr4620
+    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +g4hepem +geant4 +json +onnx +podio +python +svg +root +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'
       when: '^dd4hep %gcc'
@@ -329,7 +329,7 @@ packages:
     - '@0.0.3'
   npsim:
     require:
-    - '@1.6.0'
+    - '@git.g4hepem'
     - +http
     - any_of: [+geocad, -geocad]
   ollama:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -36,7 +36,7 @@ packages:
   acts:
     require:
     - '@45.3.0'
-    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +g4hepem +geant4 +json +onnx +podio +python +svg +root +pr4496 +pr4502 +pr4620
+    - cxxstd=20 +dd4hep +edm4hep +examples +fatras +geant4 +json +onnx +podio +python +svg +root +pr4496 +pr4502 +pr4620
     # ACTS requires same compiler as DD4hep since compiler options are reused
     - spec: '%gcc'
       when: '^dd4hep %gcc'
@@ -126,7 +126,7 @@ packages:
   dd4hep:
     require:
     - '@1.36'
-    - +ddg4 +ddcad +edm4hep +hepmc3 +xercesc
+    - +ddg4 +ddcad +edm4hep +g4hepem +hepmc3 +xercesc
     - any_of: [+ddeve +utilityapps, -ddeve -utilityapps] # FIXME ^root +x +opengl when +utilityapps
   doxygen:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR enables the G4HepEm plugin in DD4hep, and uses it in npsim by default.

Needs:
- [x] https://github.com/eic/eic-spack/pull/954
- [ ] https://github.com/eic/npsim/pull/72

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: DD4hep G4HepEm plugin)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [x] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

EM shower physics will defer to G4HepEm.