### PR TITLE
feat: dd4hep +g4hepem

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="8d090a161331ff5e286ee094eb65adfa35aa6225"
+EICSPACK_VERSION="f081c3170ae3b3f0e4867eb499c48aba41895d73"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -126,7 +126,7 @@ packages:
   dd4hep:
     require:
     - '@1.36'
-    - +ddg4 +ddcad +edm4hep +hepmc3 +xercesc
+    - +ddg4 +ddcad +edm4hep +g4hepem +hepmc3 +xercesc
     - any_of: [+ddeve +utilityapps, -ddeve -utilityapps] # FIXME ^root +x +opengl when +utilityapps
   doxygen:
     require:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@0.1.23:'
+    - '@0.2.6:'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR enables the DD4hep's G4HepEm plugin, but in contrast to #308 it does not enable it by default in npsim. That shifts the testing back to the npsim PR.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
