### PR TITLE
fix: eic-spack: pyrobird: yank 0.2.7

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="64322887e104b5b4fbf68332951e967b5afd0ce3"
+EICSPACK_VERSION="a9277ebffb02eba2e1ddcf867a81f2323c323dac"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="0130fece0e93ab56e3be4b57cb110f0a96e41109"
+EICSPACK_VERSION="e9736f879c87815a9d5072256a8183fe50bcb641"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="8d090a161331ff5e286ee094eb65adfa35aa6225"
+EICSPACK_VERSION="f51626b3e93b5256053e2aa9b617629e43ff375f"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="e9736f879c87815a9d5072256a8183fe50bcb641"
+EICSPACK_VERSION="3bf5c9e319151578fdd16896463eba3fb4567f22"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="5bd6edb2e84e64965bbd8e69825b09d655426c95"
+EICSPACK_VERSION="0130fece0e93ab56e3be4b57cb110f0a96e41109"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="f51626b3e93b5256053e2aa9b617629e43ff375f"
+EICSPACK_VERSION="5bd6edb2e84e64965bbd8e69825b09d655426c95"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="3bf5c9e319151578fdd16896463eba3fb4567f22"
+EICSPACK_VERSION="64322887e104b5b4fbf68332951e967b5afd0ce3"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@0.1.23:'
+    - '@0.2.6'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@git.0130fece0e93ab56e3be4b57cb110f0a96e41109'
+    - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@main'
+    - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
+    - '@main'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
+    - '@git.0130fece0e93ab56e3be4b57cb110f0a96e41109'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -393,7 +393,7 @@ packages:
     - '@28.3'
   pyrobird:
     require:
-    - '@0.2.6'
+    - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
     - +xrootd
     - spec: ~batch
       when: '@:0.2.6'


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
See https://github.com/eic/eic-spack/pull/957; pyrobird v0.2.7 on pypi https://pypi.org/project/pyrobird/0.2.7/#files lists an archive of 37.7 kb, not 76 MB as for 0.2.6.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Pyrobird in eic-shell currently broken.