### PR TITLE
fix: pass same secrets in runtime_installation_{default,custom}

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -287,7 +287,7 @@ ARG TARGETPLATFORM
 # Open Container Initiative labels
 LABEL org.opencontainers.image.title="Electron-Ion Collider runtime installation image (custom configuration, $TARGETPLATFORM)"
 
-# Installation (default environment, from buildcache)
+# Installation (custom environment, from buildcache)
 RUN --mount=type=cache,target=/var/cache/spack                          \
     --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
     --mount=type=secret,id=CI_REGISTRY_USER,env=CI_REGISTRY_USER        \

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -290,6 +290,10 @@ LABEL org.opencontainers.image.title="Electron-Ion Collider runtime installation
 # Installation (default environment, from buildcache)
 RUN --mount=type=cache,target=/var/cache/spack                          \
     --mount=type=secret,id=mirrors,target=/opt/spack/etc/spack/mirrors.yaml \
+    --mount=type=secret,id=CI_REGISTRY_USER,env=CI_REGISTRY_USER        \
+    --mount=type=secret,id=CI_REGISTRY_PASSWORD,env=CI_REGISTRY_PASSWORD \
+    --mount=type=secret,id=GITHUB_REGISTRY_USER,env=GITHUB_REGISTRY_USER \
+    --mount=type=secret,id=GITHUB_REGISTRY_TOKEN,env=GITHUB_REGISTRY_TOKEN \
     <<EOF
 set -e
 spack env activate --dir ${SPACK_ENV}


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR fixes an inconsistency that appears when pushing to a new buildcache that is not public yet. In runtime_installation_default we pass secrets to allow buildcache-only installation, but in runtime_installation_custom we don't pass those secrets and require the buildcache to be publicly readable. By default, new buildcaches are not publicly readable.

Note: I'm working around this issue in #318 by setting the buildcache (now that it has been created) to public, in line with past practice. This bug only affects new buildcaches.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/containers/actions/runs/28073611479/job/83302777791?pr=318#step:15:7304)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
