### PR TITLE
feat: generate transitively-reduced spack graph svg and png

### DIFF
--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -358,10 +358,12 @@ set -e
 spack --color=never debug report | sed "s/^/ - /" | sed "s/\* \*\*//" | sed "s/\*\*//" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never find --no-groups --long --variants | sed "s/^/ - /" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never graph --dot > /opt/spack-environment/env.dot
-export PATH="/opt/local/bin:${PATH}"
-tred /opt/spack-environment/env.dot > /opt/spack-environment/env_tred.dot
-dot -Tsvg /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.svg
-dot -Tpng /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.png
+if command -v tred && command -v dot ; then
+  export PATH="/opt/local/bin:${PATH}"
+  tred /opt/spack-environment/env.dot > /opt/spack-environment/env_tred.dot
+  dot -Tsvg /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.svg
+  dot -Tpng /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.png
+fi
 EOF
 
 ## Copy custom content

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -358,6 +358,7 @@ set -e
 spack --color=never debug report | sed "s/^/ - /" | sed "s/\* \*\*//" | sed "s/\*\*//" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never find --no-groups --long --variants | sed "s/^/ - /" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never graph --dot > /opt/spack-environment/env.dot
+export PATH="/opt/local/bin:${PATH}"
 tred /opt/spack-environment/env.dot > /opt/spack-environment/env_tred.dot
 dot -Tsvg /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.svg
 dot -Tpng /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.png

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -358,6 +358,9 @@ set -e
 spack --color=never debug report | sed "s/^/ - /" | sed "s/\* \*\*//" | sed "s/\*\*//" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never find --no-groups --long --variants | sed "s/^/ - /" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never graph --dot > /opt/spack-environment/env.dot
+tred /opt/spack-environment/env.dot > /opt/spack-environment/env_tred.dot
+dot -Tsvg /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.svg
+dot -Tpng /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.png
 EOF
 
 ## Copy custom content

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -358,8 +358,8 @@ set -e
 spack --color=never debug report | sed "s/^/ - /" | sed "s/\* \*\*//" | sed "s/\*\*//" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never find --no-groups --long --variants | sed "s/^/ - /" | tee -a /etc/eic_info /etc/jug_info
 spack --color=never graph --dot > /opt/spack-environment/env.dot
-if command -v tred && command -v dot ; then
-  export PATH="/opt/local/bin:${PATH}"
+export PATH="/opt/local/bin:${PATH}"
+if command -v tred >/dev/null 2>&1 && command -v dot >/dev/null 2>&1 ; then
   tred /opt/spack-environment/env.dot > /opt/spack-environment/env_tred.dot
   dot -Tsvg /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.svg
   dot -Tpng /opt/spack-environment/env_tred.dot > /opt/spack-environment/env.png


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
We previously stopped spack package graph conversion to svg and png due to time needed to find a drawing solution. With `tred` we can do a transitive reduction of the graph, which is then tractable for drawing in seconds. So, now we generate a pretty picture.
<img width="32767" height="2577" alt="env2" src="https://github.com/user-attachments/assets/711f6d19-925b-48b4-b13a-6d8d16166d39" />

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
