### PR TITLE
chore: protobuf-6.32.1

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -401,7 +401,7 @@ packages:
     - +plot
   protobuf:
     require:
-    - '@28.3'
+    - '@32.1'
   pyrobird:
     require:
     - '@git.25b6556e473b99dbbb3b4663d34d683e28acfd5e'
@@ -516,7 +516,7 @@ packages:
     - '@3.6.0:'
   py-protobuf:
     require:
-    - '@5.28.3'
+    - '@6.32.1'
   py-pygithub:
     require:
     - '@2.1.1:'


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR upgrades (py-)protobuf to (6.)32.1. This allows setuptools to be newer than v81.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: protobuf-6.32.1)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
