### PR TITLE
fix: avoid installing g4nudexlib, g4tend, g4urrpt

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -226,11 +226,29 @@ packages:
     externals:
     - spec: g4ndl@4.7.1
       prefix: /opt/software/externals/g4ndl
+  g4nudexlib:
+    buildable: False
+    externals:
+    - spec: g4nudexlib@1.0
+      prefix: /opt/software/externals/g4nudexlib
+  g4tendl:
+    buildable: False
+    externals:
+    - spec: g4tendl@1.4
+      prefix: /opt/software/externals/g4tendl
+  g4urrpt:
+    buildable: False
+    externals:
+    - spec: g4urrpt@1.1
+      prefix: /opt/software/externals/g4urrpt
   geant4:
     require:
     - '@11.3.2.east'
     - cxxstd=20 -vecgeom +threads -vtk
     - any_of: [+opengl +qt +x11, -opengl -qt -x11]
+  geant4-data:
+    require:
+    - +nudexlib +tendl +urrpt
   gettext:
     require:
     - +libxml2


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Until the spack-v1.2.0 upgrade, we had:
```
 - 3v4ubgk geant4-data@11.3.0~nudexlib~tendl~urrpt build_system=bundle
```
but in spack-v1.2.0 the concretization weights defaults (true) more strongly so we get:
```
 - iaiagej geant4-data@11.3.0+nudexlib+tendl+urrpt build_system=bundle
```
This adds ~1GB to the containers for optional data sets which most people don't use (only when using `_HP` physics lists for `g4tendl`, and the others even more difficult to get to), so in this PR we give them the same treatment as `g4ndl`: bring your own data and bind-mount it under externals.

This should make #289 happy again.

Note: At some point I think we should by default bind-mount `/cvmfs` if it is available, and then we can just by default have these datasets point to the geant4 repository location. That would make this easier to use for everyone (and set us up for other artifact distribution strategies via cvmfs).

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
