### PR TITLE
fix: eic-spack: dd4hep: backport "OSError raised by getpass.getuser()" patch

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="01aaad210b55164d6c249fed94f040d9272c6f39"
+EICSPACK_VERSION="b1ebb8295dc864f40a30820250200b65102735c0"


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR updates eic-spack to the commit with the DD4hep backport of the "OSError raised by getpass.getuser()" patch.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
