### PR TITLE
dd4hep: backport "OSError raised by getpass.getuser()" patch

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="01aaad210b55164d6c249fed94f040d9272c6f39"
+EICSPACK_VERSION="b1ebb8295dc864f40a30820250200b65102735c0"


### PR DESCRIPTION
Applies https://github.com/eic/eic-spack/pull/968