### PR TITLE
fix: use external openglu as glu, not mesa-glu

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -261,6 +261,9 @@ packages:
   gl:
     require:
     - glx
+  glu:
+    require:
+    - openglu
   gloo:
     require:
     - '@2023-12-03'
@@ -381,6 +384,11 @@ packages:
     buildable: False
     externals:
     - spec: opengl@4.6
+      prefix: /usr
+  openglu:
+    buildable: False
+    externals:
+    - spec: openglu@1.3
       prefix: /usr
   openldap:
     require:


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR ensures that the virtual provider `glu` resolves to the external `openglu` (which is the same external packages as `opengl`), instead of `mesa-glu`.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: `mesa-glu` left despite no `mesa`)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
