### PR TITLE
fix: workaround spack config permission bug

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -343,6 +343,9 @@ git -C ${EICSPACK_ROOT} checkout ${EICSPACK_SHA:-${EICSPACK_VERSION}}
 spack repo add --scope spack "${EICSPACK_ROOT}/spack_repo/eic"
 EOF
 
+## Workaround for Spack creating config files with limited permissions (see https://github.com/spack/spack/issues/52651)
+RUN chmod 644 ${SPACK_ROOT}/etc/spack/*.yaml ${HOME}/.spack/*.yaml
+
 ## Place cvmfs catalogs for system directories
 ## /etc and /usr are core system-directory subtrees created in the base image,
 ## and are large enough to warrant their own catalog boundaries so that CVMFS

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -371,6 +371,9 @@ spack config --scope spack add "upstreams:eic-shell:install_tree:/opt/software"
 spack config blame upstreams
 EOF
 
+## Workaround for Spack creating config files with limited permissions (see https://github.com/spack/spack/issues/52651)
+RUN chmod 644 ${SPACK_ROOT}/etc/spack/*.yaml ${HOME}/.spack/*.yaml
+
 ## Install benchmarks into the container
 ARG BENCHMARK_COM_SHA=""
 ARG BENCHMARK_DET_SHA=""


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR works around a regression in spack-v1.2 where new config files are created with 0600 permissions, regardless of directory or umask permissions. For cvmfs sandbox images this means config files are exposed as user `nobody` and unreadable by the actual user. See https://github.com/spack/spack/issues/52651. Possible solution in https://github.com/spack/spack/pull/52653 as well.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: spack config blame fails in eic-shell)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

High priority since actively broken in cvmfs in ways we couldn't test in docker containers.