### PR TITLE
feat: add flang when clang-20 or newer

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -61,9 +61,9 @@ env:
   ## To update: measure the compressed sizes of the published master images,
   ## add ~15% headroom, round up, and update here and in .gitlab-ci.yml
   ## variables.
-  SIZE_LIMIT_DEBIAN_STABLE_BASE_GIB: 0.8
-  SIZE_LIMIT_EIC_CI_GIB: 3
-  SIZE_LIMIT_EIC_XL_GIB: 4.5
+  SIZE_LIMIT_DEBIAN_STABLE_BASE_GIB: 0.9
+  SIZE_LIMIT_EIC_CI_GIB: 3.1
+  SIZE_LIMIT_EIC_XL_GIB: 4.6
 
 jobs:
   env:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,9 +34,9 @@ variables:
   ## To update: measure the current master-tag compressed image sizes using
   ## registry or CI tooling, add ~15% headroom, round up, and update here and
   ## in .github/workflows/build-push.yml env.
-  SIZE_LIMIT_DEBIAN_STABLE_BASE_GIB: "0.8"
-  SIZE_LIMIT_EIC_CI_GIB: "3"
-  SIZE_LIMIT_EIC_XL_GIB: "4.5"
+  SIZE_LIMIT_DEBIAN_STABLE_BASE_GIB: "0.9"
+  SIZE_LIMIT_EIC_CI_GIB: "3.1"
+  SIZE_LIMIT_EIC_XL_GIB: "4.6"
 
   ## is this nightly or not?
   NIGHTLY: ""

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -120,7 +120,7 @@ fi
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
 apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
-[ ${CLANG} -ge 20 ] && apt-get -yqq install flang${CLANG}
+if [ "${CLANG#-}" -ge 20 ]; then apt-get -yqq install flang${CLANG}; fi
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp
@@ -137,7 +137,7 @@ update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/
 update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff${CLANG}.py 100
 update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy${CLANG}.py 100
 update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config${CLANG} 100
-[ ${CLANG} -ge 20 ] && update-alternatives --install /usr/bin/flang flang /usr/bin/flang${CLANG} flang
+if [ "${CLANG#-}" -ge 20 ]; then update-alternatives --install /usr/bin/flang flang /usr/bin/flang${CLANG} 100; fi
 # Default to gcc
 update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc 100
 update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 100

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -120,6 +120,7 @@ fi
 apt-get -yqq update
 apt-get -yqq install cpp${GCC} gcc${GCC} g++${GCC} gfortran${GCC}
 apt-get -yqq install clang${CLANG} clang-tidy${CLANG} clang-format${CLANG} libclang${CLANG}-dev libc++${CLANG}-dev
+[ ${CLANG} -ge 20 ] && apt-get -yqq install flang${CLANG}
 apt-get -yqq autoremove
 # Remove symlinks loop in nvidia/cuda:12.5.1-devel-ubuntu24.04
 rm -f /usr/bin/cpp /etc/alternatives/cpp
@@ -136,6 +137,7 @@ update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/
 update-alternatives --install /usr/bin/clang-tidy-diff clang-tidy-diff /usr/bin/clang-tidy-diff${CLANG}.py 100
 update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy${CLANG}.py 100
 update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config${CLANG} 100
+[ ${CLANG} -ge 20 ] && update-alternatives --install /usr/bin/flang flang /usr/bin/flang${CLANG} flang
 # Default to gcc
 update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc 100
 update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 100


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR installs flang when clang-20 or newer, allowing for full llvm toolchains with fortran support.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: fortran needed for some dependencies; llvm-20 is first to provide flang)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
