### PR TITLE
feat: impose image size limit on cuda containers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,8 @@ variables:
   SIZE_LIMIT_DEBIAN_STABLE_BASE_GIB: "0.9"
   SIZE_LIMIT_EIC_CI_GIB: "3.1"
   SIZE_LIMIT_EIC_XL_GIB: "4.6"
+  SIZE_LIMIT_EIC_CUDA_GIB: "8.1"
+  SIZE_LIMIT_EIC_DEV_CUDA_GIB: "10.9"
 
   ## is this nightly or not?
   NIGHTLY: ""


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR imposes an upper limit on the image size for eic_cuda and eic_dev_cuda.

Needs:
- [x] #373 

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
