### PR TITLE
feat: pin optix-dev to 9.0.0

### DIFF
--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -397,6 +397,9 @@ packages:
     require:
     - '@2.1.4:'
     - processes=ppvj,ppjj
+  optix-dev:
+    require:
+    - '@9.0.0'
   osg-ca-certs:
     require:
     - '@1.141.igtf.1.141'


### PR DESCRIPTION
We need to explicitly constrain the version to 9.0.0 so it is compatible
with NVIDIA GPU driver version >= 570. This enables running on systems
that do not yet support OptiX 9.1.
