### PR TITLE
Install the EIC MCP stack and opencode via spack packages

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -1,8 +1,10 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034  # Variables are used by scripts that source this file
 ## EIC spack organization and repository, e.g. eic/eic-spack
-EICSPACK_ORGREPO="eic/eic-spack"
+## TESTING ONLY — revert to eic/eic-spack + the merge SHA before undrafting.
+## The pinned commit is develop@dd8a73e + the MCP/opencode recipes.
+EICSPACK_ORGREPO="aprozo/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="dd8a73e348ec36c685da707c2d33f1d94b8df82c"
+EICSPACK_VERSION="f356d6b81a19173901ef1e68eb2bb59099610b5f"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -383,6 +383,9 @@ packages:
     require:
     - '@7.8.1:'
     - +application_framework -vtk
+  opencode:
+    require:
+    - '@1.18.3:'
   opengl:
     buildable: False
     externals:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -158,6 +158,9 @@ packages:
     externals:
     - spec: egl@1.5.0
       prefix: /usr
+  eic-mcp:
+    require:
+    - '@main'  # pin to the first tagged release once eic/eic-mcp tags one
   eic-opticks:
     require:
     - '@0.3.0'
@@ -510,6 +513,10 @@ packages:
   py-matplotlib:
     require:
     - '@3.10'  # avoid FT_Render_Glyph errors possibly due to https://github.com/matplotlib/matplotlib/pull/30059
+  py-mcp:
+    require:
+    - '@1.28:'
+    - +cli  # rucio-eic-mcp-server needs mcp[cli]
   py-mplhep:
     require:
     - '@0.4.0:'
@@ -622,6 +629,9 @@ packages:
     - '@6.38.04'
     - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
+  rucio-eic-mcp-server:
+    require:
+    - '@0.1.0:'
   sherpa:
     require:
     - '@3.0.1'
@@ -665,6 +675,9 @@ packages:
   strace:
     require:
     - -mpers
+  supergateway:
+    require:
+    - '@3.4.3:'
   swig:
     require:
     - '@4.1:'  # constrain to avoid duplicates in eic_tf
@@ -675,6 +688,9 @@ packages:
     require:
     - '@2.8.0'
     - -xnnpack
+  uproot-mcp-server:
+    require:
+    - '@0.1.0:'
   valgrind:
     require:
     - '@3.20.0:'
@@ -688,9 +704,15 @@ packages:
     require:
     - '@5.7.0:'
     - cxxstd=20 -davix +python +scitokens-cpp
+  xrootd-mcp-server:
+    require:
+    - '@0.1.0:'
   yoda:
     require:
     - '@2.1.0:'
+  zenodo-mcp-server:
+    require:
+    - '@0.1.0:'
   zlib-api:
     require:
     - zlib-ng

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -70,6 +70,7 @@ spack:
   - ollama
   - onnx
   - opencascade
+  - opencode
   - osg-ca-certs
   - pelican
   - phonebook-cli

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -28,6 +28,7 @@ spack:
   - doxygen
   - east
   - edm4hep
+  - eic-mcp
   - eic-smear
   - eigen
   - emacs
@@ -126,6 +127,7 @@ spack:
   - py-yapf
   - rivet
   - root
+  - rucio-eic-mcp-server
   - sherpa
   - simsipm
   - slurm sysconfdir=/etc/slurm
@@ -133,6 +135,8 @@ spack:
   - spdlog
   - stow
   - strace
+  - supergateway
+  - uproot-mcp-server
   - valgrind
   - xeyes
   - xrootd


### PR DESCRIPTION
Draft — CI test build for the MCP packaging restructure (supersedes #328, per Wouter's review there: no single-file script in this repo, no runtime clone/build; everything installed properly via packages).

## What

- **spack-environment/xl/spack.yaml**: add `eic-mcp`, `opencode`, `rucio-eic-mcp-server`, `supergateway`, `uproot-mcp-server` (`xrootd-mcp-server`/`zenodo-mcp-server` were already in).
- **packages.yaml**: version/variant requires for the new packages; `py-mcp +cli`.
- Drop `containers/eic/eic-mcp` and its Dockerfile `COPY` — the launcher now comes from the `eic-mcp` spack package (repo: eic/eic-mcp, reworked to service management only in eic/eic-mcp#1) and lands in `/opt/local/bin` via the view.
- **eic-spack.sh**: TEMPORARY pin to `aprozo/eic-spack@feat/mcp-servers` which carries the new recipes (py-mcp + missing deps, the servers, supergateway, opencode, py-pyjwt 2.10.1 override). Will be reverted to `eic/eic-spack` at the merge SHA once the eic-spack PR lands — keeping this PR draft until then.

## Why the current image ships a broken xrootd-mcp-server

`npm install --global .` from a git checkout never compiled the TypeScript (released tags have no `prepare` hook), and `build/` is gitignored with no `files` list so `npm pack` drops the compiled tree anyway. The updated recipes build explicitly and neutralize the ignore; verified in `eicweb/eic_xl:nightly` that the fixed `xrootd-mcp-server`/`zenodo-mcp-server` installs ship `build/src/index.js` and runnable console commands.

## Testing done (locally, inside eicweb/eic_xl:nightly)

- All 11 new/changed packages concretize; supergateway, opencode, py-pyjwt 2.10.1, py-httpx-sse, py-sse-starlette, py-restrictedpython, and the two fixed node servers spack-install cleanly.
- End-to-end: `eic-mcp up` with the installed servers → MCP initialize + tools/list served on ports 9101–9104 (11/16/13/9 tools), two concurrent clients OK, config writers for 7 LLM clients validated, port-conflict/stale-pidfile/missing-server edge cases pass, and no git/pip/npm/npx is ever spawned at runtime.
- `opencode --version` runs inside the image (glibc OK).