### PR TITLE
Install the EIC MCP stack and opencode via spack packages

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -1,8 +1,10 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034  # Variables are used by scripts that source this file
 ## EIC spack organization and repository, e.g. eic/eic-spack
-EICSPACK_ORGREPO="eic/eic-spack"
+## TESTING ONLY — revert to eic/eic-spack + the merge SHA before undrafting.
+## The pinned commit is develop@dd8a73e + the MCP/opencode recipes.
+EICSPACK_ORGREPO="aprozo/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="dd8a73e348ec36c685da707c2d33f1d94b8df82c"
+EICSPACK_VERSION="f356d6b81a19173901ef1e68eb2bb59099610b5f"

--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -1,10 +1,10 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034  # Variables are used by scripts that source this file
 ## EIC spack organization and repository, e.g. eic/eic-spack
-## TESTING ONLY — revert to eic/eic-spack + the merge SHA before undrafting.
-## The pinned commit is develop@dd8a73e + the MCP/opencode recipes.
-EICSPACK_ORGREPO="aprozo/eic-spack"
+EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="f356d6b81a19173901ef1e68eb2bb59099610b5f"
+## TESTING: head of eic-spack#986 (develop@dd8a73e + the MCP/opencode
+## recipes); bump to the merge SHA before undrafting.
+EICSPACK_VERSION="44bb45e3d8874740410d7152ce8f778893dcb86b"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -383,6 +383,9 @@ packages:
     require:
     - '@7.8.1:'
     - +application_framework -vtk
+  opencode:
+    require:
+    - '@1.18.3:'
   opengl:
     buildable: False
     externals:

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -158,6 +158,9 @@ packages:
     externals:
     - spec: egl@1.5.0
       prefix: /usr
+  eic-mcp:
+    require:
+    - '@main'  # pin to the first tagged release once eic/eic-mcp tags one
   eic-opticks:
     require:
     - '@0.3.0'
@@ -510,6 +513,10 @@ packages:
   py-matplotlib:
     require:
     - '@3.10'  # avoid FT_Render_Glyph errors possibly due to https://github.com/matplotlib/matplotlib/pull/30059
+  py-mcp:
+    require:
+    - '@1.28:'
+    - +cli  # rucio-eic-mcp-server needs mcp[cli]
   py-mplhep:
     require:
     - '@0.4.0:'
@@ -622,6 +629,9 @@ packages:
     - '@6.38.04'
     - cxxstd=20 +fftw +fortran +gdml +http -ipo +mlp +python +root7 +tmva +tmva-sofie +x +xrootd +ssl
     - any_of: [+opengl +webgui, -opengl -webgui]
+  rucio-eic-mcp-server:
+    require:
+    - '@0.1.0:'
   sherpa:
     require:
     - '@3.0.1'
@@ -665,6 +675,9 @@ packages:
   strace:
     require:
     - -mpers
+  supergateway:
+    require:
+    - '@3.4.3:'
   swig:
     require:
     - '@4.1:'  # constrain to avoid duplicates in eic_tf
@@ -675,6 +688,9 @@ packages:
     require:
     - '@2.8.0'
     - -xnnpack
+  uproot-mcp-server:
+    require:
+    - '@0.1.0:'
   valgrind:
     require:
     - '@3.20.0:'
@@ -688,9 +704,15 @@ packages:
     require:
     - '@5.7.0:'
     - cxxstd=20 -davix +python +scitokens-cpp
+  xrootd-mcp-server:
+    require:
+    - '@0.1.0:'
   yoda:
     require:
     - '@2.1.0:'
+  zenodo-mcp-server:
+    require:
+    - '@0.1.0:'
   zlib-api:
     require:
     - zlib-ng

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -519,7 +519,8 @@ packages:
   py-mcp:
     require:
     - '@1.28:'
-    - +cli  # rucio-eic-mcp-server needs mcp[cli]
+    # no +cli: the typer-based mcp CLI pins py-click@:8.1.8, which cannot
+    # unify with the environment's click 8.3+ (flask); servers need mcp core
   py-mplhep:
     require:
     - '@0.4.0:'

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -70,6 +70,7 @@ spack:
   - ollama
   - onnx
   - opencascade
+  - opencode
   - osg-ca-certs
   - pelican
   - phonebook-cli

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -28,6 +28,7 @@ spack:
   - doxygen
   - east
   - edm4hep
+  - eic-mcp
   - eic-smear
   - eigen
   - emacs
@@ -126,6 +127,7 @@ spack:
   - py-yapf
   - rivet
   - root
+  - rucio-eic-mcp-server
   - sherpa
   - simsipm
   - slurm sysconfdir=/etc/slurm
@@ -133,6 +135,8 @@ spack:
   - spdlog
   - stow
   - strace
+  - supergateway
+  - uproot-mcp-server
   - valgrind
   - xeyes
   - xrootd


### PR DESCRIPTION
Supersedes #328 (per review there: no bundled script, no runtime clone/build — everything installed properly via packages) and replaces #356 (same change from a fork, where CI has no secrets).

Three commits:
1. **feat: install the EIC MCP server stack via spack packages** — xl/spack.yaml adds `eic-mcp`, `rucio-eic-mcp-server`, `supergateway`, `uproot-mcp-server` (xrootd/zenodo were already in); packages.yaml version requires + `py-mcp +cli`.
2. **feat: opencode** — AI coding agent CLI for headless use (farm nodes, CI reproducers).
3. **chore: TESTING pin** — `eic-spack.sh` points at the recipes branch (eic/eic-spack#986 head, i.e. develop@dd8a73e + the new recipes). This commit is dropped/reverted to the merge SHA before undrafting.

Why the current image ships a broken xrootd-mcp-server, test evidence (all recipe installs verified in `eicweb/eic_xl:nightly`, 22/22 end-to-end launcher tests, MCP served on 9101–9104): see the eic-spack PR and eic/eic-mcp#1.

Draft until the eic-spack PR merges and the pin is finalized.
