### PR TITLE
feat: hepmcmerger 2.4.0, eicrecon 1.39.2

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="dd8a73e348ec36c685da707c2d33f1d94b8df82c"
+EICSPACK_VERSION="5476d222efd992e87e6906fa92b78df3cb2aacec"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -166,7 +166,7 @@ packages:
     - '@1.2.2'
   eicrecon:
     require:
-    - '@1.39.1' # EICRECON_VERSION
+    - '@1.39.2' # EICRECON_VERSION
   eigen:
     require:
     - '@3.4.0'
@@ -283,7 +283,7 @@ packages:
     - +python +rootio
   hepmcmerger:
     require:
-    - '@2.3.0'
+    - '@2.4.0'
   heppdt:
     require:
     - '@2.06.01'


### PR DESCRIPTION
Two separate changes:
- https://github.com/eic/HEPMC_Merger/releases/tag/v2.4.0
- https://github.com/eic/EICrecon/releases/tag/v1.39.2