### PR TITLE
Fix new-installer upstream fallback for eic-shell installs

### DIFF
--- a/spack.sh
+++ b/spack.sh
@@ -12,6 +12,7 @@ read -r -d '' SPACK_CHERRYPICKS <<- \
 --- || true
 292b0dcaba3b2a5e3f9668d205d39fee2c715721
 678e506a95b319c573ba7e84703b06d7275ab80e
+913c85673a3ce076ef905489826d3f9d8adb7e54
 ---
 ## Optional hash table with comma-separated file list
 read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
@@ -21,3 +22,4 @@ read -r -d '' SPACK_CHERRYPICKS_FILES <<- \
 ## [hash]: [description]
 ## 292b0dcaba3b2a5e3f9668d205d39fee2c715721: fix: write created time field with OCI buildcache config
 ## 678e506a95b319c573ba7e84703b06d7275ab80e: fix: don't map prefix to view root for pkgs excluded from view
+## 913c85673a3ce076ef905489826d3f9d8adb7e54: new_installer.py: allow local install if missing upstream


### PR DESCRIPTION
Spack installs inside `eic-shell` were failing in finalization with the new installer, while `config:installer:old` worked as a workaround. This updates our Spack cherry-picks to take the upstream fix path instead of forcing the legacy installer.

This change adds the merged upstream fix commit from `spack/spack` PR #52630 to `SPACK_CHERRYPICKS` in `spack.sh`, with the corresponding annotation:
- `913c85673a3ce076ef905489826d3f9d8adb7e54` (`new_installer.py: allow local install if missing upstream`)

This keeps the new installer enabled and aligns container behavior with the upstream resolution for missing-upstream install handling.

Fixes: #369