### PR TITLE
fix: bump py-llvmlite/py-numba to use llvm@20 after clang-20 upgrade

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -58,6 +58,7 @@ apt-get -yqq install --no-install-recommends                            \
         libglew-dev                                                     \
         libglx-dev                                                      \
         libopengl-dev                                                   \
+        libzstd-dev                                                     \
         locales                                                         \
         make                                                            \
         moreutils                                                       \

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -514,7 +514,7 @@ packages:
     - backend=tensorflow
   py-llvmlite:
     require:
-    - '@0.44.0'
+    - '@0.45.1:'
   py-lmfit:
     require:
     - '@1.0.2:'
@@ -529,7 +529,7 @@ packages:
     - '@5.8:' # avoid py-jupyter-server and snakemake divergence
   py-numba:
     require:
-    - '@0.61.0:'
+    - '@0.62.0:'
   py-numpy:
     require:
     - '@2.2'  # pin to avoid duplicates in eic_tf

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -514,7 +514,7 @@ packages:
     - backend=tensorflow
   py-llvmlite:
     require:
-    - '@0.45.1:'
+    - '@0.45.1:0.47'  # limited by llvm@20
   py-lmfit:
     require:
     - '@1.0.2:'
@@ -529,7 +529,7 @@ packages:
     - '@5.8:' # avoid py-jupyter-server and snakemake divergence
   py-numba:
     require:
-    - '@0.62.0:'
+    - '@0.62.0:0.65'  # limited by llvm@20
   py-numpy:
     require:
     - '@2.2'  # pin to avoid duplicates in eic_tf


### PR DESCRIPTION
After upgrading the cuda environment to clang-20 (#88), `py-llvmlite@0.44` (which requires `llvm@15:16`) can no longer reuse the compiler's llvm and instead builds a separate `llvm@16` from scratch — a large, redundant install.

`py-llvmlite@0.45+` requires `llvm@20`, matching the clang-20 compiler already in the image.
`py-numba@0.62+` is required to map to `py-llvmlite@0.45+`.

The dependency chain is:
`py-pandas` (+performance default) → `py-numba` → `py-llvmlite` → `llvm`