### PR TITLE
docs(debian): annotate apt package roles in base image

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -37,40 +37,44 @@ rm -f /etc/apt/apt.conf.d/docker-clean
 ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 echo "US/Eastern" > /etc/timezone
 apt-get -yqq update
-apt-get -yqq install --no-install-recommends                            \
-        bc                                                              \
-        bzip2                                                           \
-        ca-certificates                                                 \
-        ccache                                                          \
-        curl                                                            \
-        file                                                            \
-        gawk                                                            \
-        gdb                                                             \
-        git                                                             \
-        gnupg2                                                          \
-        iproute2                                                        \
-        iputils-ping                                                    \
-        iputils-tracepath                                               \
-        less                                                            \
-        libc6-dbg                                                       \
-        libegl-dev                                                      \
-        libgl-dev                                                       \
-        libglew-dev                                                     \
-        libglx-dev                                                      \
-        libopengl-dev                                                   \
-        libzstd-dev                                                     \
-        locales                                                         \
-        make                                                            \
-        moreutils                                                       \
-        nano                                                            \
-        openssh-client                                                  \
-        parallel                                                        \
-        patch                                                           \
-        time                                                            \
-        unzip                                                           \
-        vim-nox                                                         \
-        wget                                                            \
-        yq
+# Keep these in the base layer for OS setup, Spack prerequisites, or
+# system externals that we do not want rebuilt inside Spack.
+sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' <<'EOF_APT_PACKAGES' \
+  | xargs -r apt-get -yqq install --no-install-recommends
+bc                # bootstrap script helper
+bzip2             # Spack prerequisite
+ca-certificates   # system CA trust for apt/git/curl
+ccache            # shared compiler cache outside Spack prefixes
+curl              # bootstrap downloader
+file              # Spack prerequisite
+gawk              # script helper
+gdb               # system debugger
+git               # Spack prerequisite
+gnupg2            # buildcache signing/verification
+iproute2          # network diagnostics
+iputils-ping      # network diagnostics
+iputils-tracepath # network diagnostics
+less              # base pager
+libc6-dbg         # debug symbols for the system glibc
+libegl-dev        # system GL external; avoids bundling Mesa/LLVM swrast in Spack
+libgl-dev         # system GL external; avoids bundling Mesa/LLVM swrast in Spack
+libglew-dev       # system GL external; avoids bundling Mesa/LLVM swrast in Spack
+libglx-dev        # system GL external; avoids bundling Mesa/LLVM swrast in Spack
+libopengl-dev     # system GL external; avoids bundling Mesa/LLVM swrast in Spack
+libzstd-dev       # undeclared dependency of llvm-dev
+locales           # OS locale generation
+make              # Spack prerequisite
+moreutils         # script helper
+nano              # base editor
+openssh-client    # SSH transport outside Spack envs
+parallel          # script helper
+patch             # Spack prerequisite
+time              # build timing/debugging
+unzip             # Spack prerequisite
+vim-nox           # base editor
+wget              # bootstrap downloader
+yq                # edits Spack config before install
+EOF_APT_PACKAGES
 apt-get -yqq autoremove
 localedef -i en_US -f UTF-8 en_US.UTF-8
 EOF
@@ -152,11 +156,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-${TARGETPLATF
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked,id=apt-lists-${TARGETPLATFORM} <<EOF
 rm -f /etc/apt/apt.conf.d/docker-clean
 apt-get -yqq update
-apt-get -yqq install --no-install-recommends                            \
-        jq                                                              \
-        python3                                                         \
-        python3-dev                                                     \
-        python-is-python3
+# Spack relies on basic utilities being present on the system where it runs.
+sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' <<'EOF_APT_PACKAGES' \
+  | xargs -r apt-get -yqq install --no-install-recommends
+jq                # repo script helper
+python3           # Spack prerequisite
+python3-dev       # Python extension builds during bootstrap
+python-is-python3 # repo scripts expect `python`
+EOF_APT_PACKAGES
 EOF
 
 ## Setup git


### PR DESCRIPTION
Needs:
- [x] #373 

This documents why the Debian base image installs these packages with apt instead of leaving the question to Spack-managed environments. Reviewers should be able to see which packages are OS setup, Spack prerequisites, or deliberate system externals at a glance.

The Dockerfile now feeds the apt package lists through a commented heredoc using `sed` and `xargs`, so each package can carry an inline justification without changing the installed package set. The same pattern is used for the base tools block and the Spack runtime dependency block.

Notable details:
- keeps the installed package set equivalent
- shortens the justifications to the minimum useful rationale
- calls out the GL development packages as system externals to avoid bundling Mesa/LLVM swrast in Spack

Validation:
- `docker buildx build -f containers/debian/Dockerfile containers/debian`