### PR TITLE
feat: rm juggler/gaudi

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,10 +17,6 @@ on:
         required: false
         default: ''
         type: string
-      JUGGLER_VERSION:
-        required: false
-        default: ''
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -39,7 +35,6 @@ env:
   ## note: nightly builds will always use the master/main branch
   EDM4EIC_VERSION: ${{ inputs.EDM4EIC_VERSION }}
   EICRECON_VERSION: ${{ inputs.EICRECON_VERSION }}
-  JUGGLER_VERSION: ${{ inputs.JUGGLER_VERSION }}
 
   ## Dockerhub registry
   DH_REGISTRY: docker.io

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ variables:
   EDM4EIC_VERSION: ""
   EICRECON_VERSION: ""
   EPIC_VERSION: ""
-  JUGGLER_VERSION: ""
 
   ## Local registry
   CI_PUSH: 1

--- a/containers/eic/Dockerfile
+++ b/containers/eic/Dockerfile
@@ -151,7 +151,6 @@ ENV SPACK_ENV=/opt/spack-environment/${ENV}/epic
 ARG EDM4EIC_SHA=""
 ARG EICRECON_SHA=""
 ARG EPIC_SHA=""
-ARG JUGGLER_SHA=""
 
 # Concretization (custom environment)
 RUN --mount=type=cache,target=/root/.spack/cache/concretization,id=spack-concretization-${TARGETPLATFORM} \
@@ -170,10 +169,6 @@ if [ -n "${EPIC_SHA}" ] ; then
   sed -i "/# EPIC_VERSION$/ s/epic\s/epic@git.${EPIC_SHA}=main /" /opt/spack-environment/${ENV}/epic/spack.yaml
   sed -i "/# EPIC_VERSION$/ s/epic@main\s/epic@git.${EPIC_SHA}=main /" /opt/spack-environment/${ENV}/epic/spack.yaml
   spack deconcretize -y --all epic
-fi
-if [ -n "${JUGGLER_SHA}" ] ; then
-  sed -i "/# JUGGLER_VERSION$/ s/@[^' ]*/@git.${JUGGLER_SHA}=main/" /opt/spack-environment/packages.yaml
-  spack deconcretize -y --all juggler
 fi
 spack concretize --force
 EOF

--- a/docs/building-locally.md
+++ b/docs/building-locally.md
@@ -205,7 +205,6 @@ directly, Dockerfile `ARG` defaults apply instead.
 | `EDM4EIC_SHA` | Custom edm4eic commit | |
 | `EICRECON_SHA` | Custom eicrecon commit | |
 | `EPIC_SHA` | Custom epic commit | |
-| `JUGGLER_SHA` | Custom juggler commit | |
 
 ## Troubleshooting
 

--- a/docs/spack-environment.md
+++ b/docs/spack-environment.md
@@ -129,7 +129,6 @@ spack:
   - epic@25.08.0           # Tagged versions
   - epic@25.09.0
   - epic@25.10.0
-  - juggler
 ```
 
 ## Version Control
@@ -239,7 +238,6 @@ spack:
 | `eicrecon` | EIC reconstruction framework |
 | `epic` | EPIC detector geometry |
 | `npsim` | Nuclear physics simulation |
-| `juggler` | Gaudi algorithms for EIC |
 | `irt` | Imaging RICH Toolkit |
 
 ### Development Tools

--- a/scripts/build-eic.sh
+++ b/scripts/build-eic.sh
@@ -187,18 +187,16 @@ for build_type in "${BUILD_TYPES[@]}"; do
   build_type="${build_type#"${build_type%%[![:space:]]*}"}"; build_type="${build_type%"${build_type##*[![:space:]]}"}"
 
   ## Resolve optional version overrides (nightly always resolves; default only if version set)
-  unset EDM4EIC_SHA EICRECON_SHA EPIC_SHA JUGGLER_SHA
+  unset EDM4EIC_SHA EICRECON_SHA EPIC_SHA
   if [ "${build_type}" = "nightly" ]; then
     EDM4EIC_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/EDM4eic "${EDM4EIC_VERSION:-main}")
     EICRECON_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/EICrecon "${EICRECON_VERSION:-main}")
     EPIC_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/epic "${EPIC_VERSION:-main}")
-    JUGGLER_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/juggler "${JUGGLER_VERSION:-main}")
   else
     ## default build: only resolve if version is explicitly provided
     [ -n "${EDM4EIC_VERSION}" ]  && EDM4EIC_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/EDM4eic  "${EDM4EIC_VERSION}")
     [ -n "${EICRECON_VERSION}" ] && EICRECON_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref" eic/EICrecon "${EICRECON_VERSION}")
     [ -n "${EPIC_VERSION}" ]     && EPIC_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref"     eic/epic     "${EPIC_VERSION}")
-    [ -n "${JUGGLER_VERSION}" ]  && JUGGLER_SHA=$(sh "${REPO_DIR}/scripts/resolve_git_ref"  eic/juggler  "${JUGGLER_VERSION}")
   fi
 
   ## Build the docker buildx command as an array for safe quoting
@@ -286,7 +284,6 @@ for build_type in "${BUILD_TYPES[@]}"; do
   [ -n "${EDM4EIC_SHA}" ]  && build_cmd+=(--build-arg "EDM4EIC_SHA=${EDM4EIC_SHA}")
   [ -n "${EICRECON_SHA}" ] && build_cmd+=(--build-arg "EICRECON_SHA=${EICRECON_SHA}")
   [ -n "${EPIC_SHA}" ]     && build_cmd+=(--build-arg "EPIC_SHA=${EPIC_SHA}")
-  [ -n "${JUGGLER_SHA}" ]  && build_cmd+=(--build-arg "JUGGLER_SHA=${JUGGLER_SHA}")
 
   ## Additional build contexts
   build_cmd+=(--build-context "spack-environment=spack-environment")

--- a/spack-environment/ci_without_acts/spack.yaml
+++ b/spack-environment/ci_without_acts/spack.yaml
@@ -16,7 +16,6 @@ spack:
   - fastjet
   - fjcontrib
   - fmt
-  - gaudi
   - geant4 -opengl
   - gfal2
   - gfal2-util

--- a/spack-environment/cuda/epic/spack.yaml
+++ b/spack-environment/cuda/epic/spack.yaml
@@ -26,4 +26,3 @@ spack:
   - epic@26.07.0
   - epic@26.07.1
   - epic@26.07.2
-  - juggler

--- a/spack-environment/cuda/spack.yaml
+++ b/spack-environment/cuda/spack.yaml
@@ -31,7 +31,6 @@ spack:
   - fjcontrib
   - fmt
   - g4adept +cuda
-  - gaudi
   - gdb
   - geant4
   - graphviz
@@ -42,8 +41,6 @@ spack:
   - irt2
   - jana2
   - just
-  - k4actstracking
-  - k4fwcore
   - lcov
   - lhapdf
   - lhapdfsets

--- a/spack-environment/cvmfs/epic/spack.yaml
+++ b/spack-environment/cvmfs/epic/spack.yaml
@@ -11,4 +11,3 @@ spack:
   - edm4eic
   - eicrecon
   - epic@main # EPIC_VERSION
-  - juggler

--- a/spack-environment/cvmfs/spack.yaml
+++ b/spack-environment/cvmfs/spack.yaml
@@ -18,7 +18,6 @@ spack:
   - fastjet
   - fjcontrib
   - fmt
-  - gaudi
   - geant4 -opengl
   - gfal2
   - gfal2-util

--- a/spack-environment/prod/epic/spack.yaml
+++ b/spack-environment/prod/epic/spack.yaml
@@ -10,4 +10,3 @@ spack:
   - edm4eic
   - eicrecon
   - epic@main # EPIC_VERSION
-  - juggler

--- a/spack-environment/prod/spack.yaml
+++ b/spack-environment/prod/spack.yaml
@@ -10,7 +10,6 @@ spack:
   - dd4hep
   - fastjet
   - fjcontrib
-  - gaudi
   - geant4 -opengl
   - hepmc3
   - irt

--- a/spack-environment/xl/epic/spack.yaml
+++ b/spack-environment/xl/epic/spack.yaml
@@ -26,4 +26,3 @@ spack:
   - epic@26.07.0
   - epic@26.07.1
   - epic@26.07.2
-  - juggler

--- a/spack-environment/xl/spack.yaml
+++ b/spack-environment/xl/spack.yaml
@@ -38,7 +38,6 @@ spack:
   - fjcontrib
   - fmt
   - g4occt
-  - gaudi
   - gdb
   - geant4 +opengl
   - gfal2
@@ -55,8 +54,6 @@ spack:
   - iwyu
   - jana2
   - just
-  - k4actstracking
-  - k4fwcore
   - lcov
   - lhapdf
   - lhapdfsets


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes `juggler` and `gaudi` from the software stack. It is now not used anymore by anything. We also don't need explicit `k4actstracking` and `k4fwcore` anymore. We keep the restrictions inside `packages.yaml` since people may still want to install these packages in their local environments, and the minimum versions still apply.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue: remove unused dependencies)
- [x] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
