### PR TITLE
feat: npsim 1.8.0

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="a3a66f817b8a2a7fe8cccdff26ab41ad44ccf1bc"
+EICSPACK_VERSION="8fc28f931a824457d112cc1d26c6132123d718c8"

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -380,7 +380,7 @@ packages:
     - '@0.0.3'
   npsim:
     require:
-    - '@1.7.0'
+    - '@1.8.0'
     - +http
     - any_of: [+geocad, -geocad]
   ollama:


### PR DESCRIPTION
https://github.com/eic/npsim/releases/tag/v1.8.0

Primary feature is that we'll be storing sensor-hitting optical photons in MCParticles (needed for IRT2).