### PR TITLE
hotfix: make eic-manifest need optional

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,15 +386,9 @@ eic:
     matrix:
       ## Build both default and nightly sequentially in one job to reuse the shared
       ## base Docker stages (default concretization+installation) from BuildKit's layer cache.
-      - &eic_ci_matrix_entry
-        BUILD_IMAGE: eic_
-        ENV: ci
-        BUILD_TYPE: "default,nightly"
-        BUILDER_IMAGE: debian_stable_base
-        RUNTIME_IMAGE: debian_stable_base
-        PLATFORM: linux/amd64
       - BUILD_IMAGE: eic_
         ENV:
+        - ci
         - cvmfs
         - xl
         BUILD_TYPE: "default,nightly"
@@ -480,19 +474,10 @@ eic:
 eic-manifest:
   extends: .docker
   stage: eic-manifest
-  rules:
-    # External trigger pipelines (e.g. EICrecon) only build eic_ci; narrow needs to that matrix child.
-    - if: '$CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
-      needs:
-        - job: version
-        - job: eic
-          parallel:
-            matrix:
-              - *eic_ci_matrix_entry
-    - when: always
   needs:
     - version
     - job: eic
+      optional: true
   script:
     - apk add bash jq
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,9 +386,15 @@ eic:
     matrix:
       ## Build both default and nightly sequentially in one job to reuse the shared
       ## base Docker stages (default concretization+installation) from BuildKit's layer cache.
+      - &eic_ci_matrix_entry
+        BUILD_IMAGE: eic_
+        ENV: ci
+        BUILD_TYPE: "default,nightly"
+        BUILDER_IMAGE: debian_stable_base
+        RUNTIME_IMAGE: debian_stable_base
+        PLATFORM: linux/amd64
       - BUILD_IMAGE: eic_
         ENV:
-        - ci
         - cvmfs
         - xl
         BUILD_TYPE: "default,nightly"
@@ -474,6 +480,16 @@ eic:
 eic-manifest:
   extends: .docker
   stage: eic-manifest
+  rules:
+    # External trigger pipelines (e.g. EICrecon) only build eic_ci; narrow needs to that matrix child.
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && $GITHUB_REPOSITORY != "eic/containers"'
+      needs:
+        - job: version
+        - job: eic
+          parallel:
+            matrix:
+              - *eic_ci_matrix_entry
+    - when: always
   needs:
     - version
     - job: eic


### PR DESCRIPTION
## Summary
- set `eic-manifest` to `needs` the parallel `eic` job with `optional: true`
- keep `version` as a required need
- preserve the external-trigger behavior where only `eic_ci` is built, without failing pipeline creation when other matrix jobs are skipped

## Motivation
On the current EICweb GitLab, rule-level matrix-selective needs for this case result in pipeline creation failure (`undefined need: eic`). Using `optional: true` is compatible and avoids hard-coding matrix child names.