### PR TITLE
ci(gitlab): streamline eic manifest DAG dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,7 +383,7 @@ base-manifest:
 
 eic:
   parallel:
-    matrix:
+    matrix: &eic_matrix
       ## Build both default and nightly sequentially in one job to reuse the shared
       ## base Docker stages (default concretization+installation) from BuildKit's layer cache.
       - BUILD_IMAGE: eic_
@@ -472,16 +472,29 @@ eic:
       fi
 
 eic-manifest:
+  parallel:
+    matrix: *eic_matrix
   extends: .docker
   stage: eic-manifest
   needs:
     - version
     - job: eic
       optional: true
+      parallel:
+        matrix:
+          - BUILD_IMAGE: ['$[[ matrix.BUILD_IMAGE ]]']
+            ENV: ['$[[ matrix.ENV ]]']
+            BUILD_TYPE: ['$[[ matrix.BUILD_TYPE ]]']
+            BUILDER_IMAGE: ['$[[ matrix.BUILDER_IMAGE ]]']
+            RUNTIME_IMAGE: ['$[[ matrix.RUNTIME_IMAGE ]]']
+            PLATFORM: ['$[[ matrix.PLATFORM ]]']
   script:
     - apk add bash jq
     - |
-      for metadata_file in build-metadata-*.json; do
+      matched=0
+      for metadata_file in build-metadata-${BUILD_IMAGE}${ENV}-*.json; do
+        [ -f "${metadata_file}" ] || continue
+        matched=1
         ## Parse filename: build-metadata-<IMAGE_NAME>-<BUILD_TYPE>.json
         base="${metadata_file#build-metadata-}"; base="${base%.json}"
         BUILD_TYPE="${base##*-}"
@@ -507,6 +520,10 @@ eic-manifest:
           [ -n "${GH_PUSH}" ] && docker buildx imagetools create --tag "${GH_REGISTRY}/${GH_REGISTRY_USER}/${IMAGE_NAME}:${NIGHTLY_TAG}" "${IMAGE_REPO}@${DIGEST}"
         fi
       done
+      if [ "${matched}" -eq 0 ]; then
+        echo "ERROR: No metadata files found for ${BUILD_IMAGE}${ENV}."
+        exit 1
+      fi
 
 user_spack_environment:
   stage: benchmarks
@@ -517,7 +534,16 @@ user_spack_environment:
     - when: always
   needs:
     - job: version
-    - job: eic-manifest
+    - &needs_eic_ci_manifest
+      job: eic-manifest
+      parallel:
+        matrix:
+          - BUILD_IMAGE: eic_
+            ENV: ci
+            BUILD_TYPE: "default,nightly"
+            BUILDER_IMAGE: debian_stable_base
+            RUNTIME_IMAGE: debian_stable_base
+            PLATFORM: linux/amd64
   image:
     name: ${CI_REGISTRY_IMAGE}/eic_ci:${INTERNAL_TAG}-default
   script:
@@ -543,6 +569,14 @@ user_spack_environment:
   needs:
     - job: version
     - job: eic-manifest
+      parallel:
+        matrix:
+          - BUILD_IMAGE: eic_dev_
+            ENV: cuda
+            BUILD_TYPE: "default,nightly"
+            BUILDER_IMAGE: cuda_devel
+            RUNTIME_IMAGE: cuda_devel
+            PLATFORM: linux/amd64
   image:
     name: ${CI_REGISTRY_IMAGE}/eic_dev_cuda:${INTERNAL_TAG}-default
 
@@ -577,7 +611,16 @@ eic_xl:singularity:default:
     BUILD_IMAGE: eic_xl
   needs:
     - job: version
-    - job: eic-manifest
+    - &needs_eic_xl_manifest
+      job: eic-manifest
+      parallel:
+        matrix:
+          - BUILD_IMAGE: eic_
+            ENV: xl
+            BUILD_TYPE: "default,nightly"
+            BUILDER_IMAGE: debian_stable_base
+            RUNTIME_IMAGE: debian_stable_base
+            PLATFORM: linux/amd64
 
 # eic-shell/install.py expects build/eic_xl.sif from the job with name 'eic_xl:singularity:nightly'
 eic_xl:singularity:nightly:
@@ -587,7 +630,7 @@ eic_xl:singularity:nightly:
     BUILD_IMAGE: eic_xl
   needs:
     - job: version
-    - job: eic-manifest
+    - *needs_eic_xl_manifest
 
 .benchmarks:
   stage: benchmarks
@@ -608,7 +651,7 @@ eic_xl:singularity:nightly:
     BUILD_TYPE: default
   needs:
     - job: version
-    - job: eic-manifest
+    - *needs_eic_ci_manifest
 
 .benchmarks:nightly:
   extends: .benchmarks
@@ -616,7 +659,7 @@ eic_xl:singularity:nightly:
     BUILD_TYPE: nightly
   needs:
     - job: version
-    - job: eic-manifest
+    - *needs_eic_ci_manifest
 
 benchmarks:geoviewer:default:
   extends: .benchmarks:default


### PR DESCRIPTION
This streamlines the GitLab pipeline DAG so jobs start as soon as their required artifacts are ready, instead of waiting on unrelated shards.

## What changed
- Converted `eic-manifest` into a matrix job aligned with the `eic` matrix.
- Added matrix-aware `needs` from each `eic-manifest` shard to its matching `eic` shard.
- Scoped manifest processing to `build-metadata-${BUILD_IMAGE}${ENV}-*.json` so each shard handles only its own image metadata.
- Added an explicit error when a manifest shard finds no matching metadata files.
- Updated downstream `needs` so benchmark and deploy jobs depend only on the specific manifest shard they require.

## Duplication reduction and synchronization
- Introduced YAML anchors/aliases for the shared `eic` matrix and reused it in `eic-manifest`.
- Introduced reusable anchored `needs` selectors for `eic_ci` and `eic_xl` manifest dependencies.

## Notes
- Behavior is unchanged for tagging logic; this is a DAG and maintainability refactor focused on earlier job starts and less duplicated CI config.