### PR TITLE
fix: spack cherry-pick: hepmc3: patch to remove cdll.LoadLibrary of unversioned libCore.so

### DIFF
--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -27,6 +27,7 @@ acac89d6bb7079412e711a50a3f06681132a2723
 438abd1e09f0cea9cb0ccc7e0326adcd0408196b
 d4fb37cedfb7552a753bdc9c0c4792082f4b46e8
 4dc856a13e9066ca3249a593d351af8cda521fa3
+c61e6769fe7556654815193f8ff2efb6cfec5fda
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -51,3 +52,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 438abd1e09f0cea9cb0ccc7e0326adcd0408196b: herwig3: add CT14(?n)lo pdfsets as build-time resources
 ## d4fb37cedfb7552a753bdc9c0c4792082f4b46e8: py-tensorflow: add libclang variant
 ## 4dc856a13e9066ca3249a593d351af8cda521fa3: root: add v6.40.00, v6.40.02
+## c61e6769fe7556654815193f8ff2efb6cfec5fda: hepmc3: patch to remove cdll.LoadLibrary of unversioned libCore.so


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR add a patch for hepmc3 to remove the unversioned cdll.LoadLibrary of libCore.so, which affects our running of the lowQ2 detector_benchmark. More details at https://github.com/spack/spack-packages/pull/5989.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/spack/spack-packages/pull/5989)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
