### PR TITLE
feat: bump to epic 26.08.0 and eicrecon 1.40.0

### DIFF
--- a/eic-spack.sh
+++ b/eic-spack.sh
@@ -5,4 +5,4 @@ EICSPACK_ORGREPO="eic/eic-spack"
 
 ## EIC spack commit hash or github version, e.g. v0.19.7
 ## note: nightly builds could use a branch e.g. releases/v0.19
-EICSPACK_VERSION="565ca6482c8ccba54b8963c741b39d8abb351267"
+EICSPACK_VERSION="b7c44c794b8e54b78c0426ff4f412281cc86cc0d"

--- a/spack-environment/cuda/epic/spack.yaml
+++ b/spack-environment/cuda/epic/spack.yaml
@@ -19,10 +19,9 @@ spack:
   - edm4eic
   - eicrecon
   - epic@main # EPIC_VERSION
-  - epic@26.04.0
-  - epic@26.04.1
   - epic@26.05.0
   - epic@26.06.0
   - epic@26.07.0
   - epic@26.07.1
   - epic@26.07.2
+  - epic@26.08.0

--- a/spack-environment/packages.yaml
+++ b/spack-environment/packages.yaml
@@ -166,7 +166,7 @@ packages:
     - '@1.2.2'
   eicrecon:
     require:
-    - '@1.39.2' # EICRECON_VERSION
+    - '@1.40.0' # EICRECON_VERSION
   eicsimubeameffects:
     require:
     - '@1.1'

--- a/spack-environment/xl/epic/spack.yaml
+++ b/spack-environment/xl/epic/spack.yaml
@@ -19,10 +19,9 @@ spack:
   - edm4eic
   - eicrecon
   - epic@main # EPIC_VERSION
-  - epic@26.04.0
-  - epic@26.04.1
   - epic@26.05.0
   - epic@26.06.0
   - epic@26.07.0
   - epic@26.07.1
   - epic@26.07.2
+  - epic@26.08.0


### PR DESCRIPTION
- Bump EICSPACK_VERSION to eic/eic-spack@b7c44c794b8e54b78c0426ff4f412281cc86cc0d
- eicrecon 1.39.2 -> 1.40.0 in spack-environment/packages.yaml
- Add epic@26.08.0 and drop epic@26.04.* in cuda/ and xl/ flavors

Notable eic-spack commits picked up:
- eic/eic-spack#1000 g4occt: add versions
- eic/eic-spack#1006 simphony: make the DD4hep plugins discoverable at runtime

Releases:
- https://github.com/eic/epic/releases/tag/26.08.0
- https://github.com/eic/EICrecon/releases/tag/v1.40.0