### PR TITLE
feat: add eic-spack source mirror

### DIFF
--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -322,11 +322,13 @@ yq -iy 'if .packages.cuda.externals then .packages.cuda.externals[].spec += " +a
 spack config blame packages
 EOF
 
-## Setup buildcache mirrors
-## - this always adds the read-only mirror to the container
-## - the write-enabled mirror is provided later as a secret mount
+## Setup source and buildcache mirrors
+## - this always adds the source mirror of eic-spack packages
+## - this always adds the read-only buildcache mirror to the container
+## - the write-enabled buildcache mirror is provided later as a secret mount
 RUN --mount=type=cache,target=/var/cache/spack <<EOF
 set -e
+spack mirror add --scope spack --type source eic-spack-mirror https://eic.github.io/eic-spack-mirror
 spack mirror add --scope spack --signed spack-${SPACK_VERSION} https://binaries.spack.io/${SPACK_VERSION}
 spack mirror add --scope spack --unsigned ghcr-${SPACKPACKAGES_VERSION} oci://ghcr.io/eic/spack-${SPACKPACKAGES_VERSION}
 spack mirror list


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR adds the eic-spack source mirror at https://github.com/eic/eic-spack-mirror. This avoids the dawn/dawncut SSL certificate issues since we can inject the source objects by hand and bypass SSL certificate checks selectively.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: dawn/dawncut SSL certificate issues)
- [x] New feature (issue: eic-spack source mirror)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
