### PR TITLE
hotfix: spack cherry-pick: acts: pass root variant to examples

### DIFF
--- a/spack-packages.sh
+++ b/spack-packages.sh
@@ -37,6 +37,7 @@ b7819dfb21e2716761e0a99bc93a851eef0e6343
 6fff3bd98c2157600cb716a3d7116f0a235446f1
 0e793b360b1383044923a19146f7d977f3107a41
 4c53d69e7e02fb346500b6269e43a26d1010d0f7
+ded706e8eb08bae4ac1cd4618c594bee4040a00e
 ---
 ## Optional hash table with comma-separated file list
 ## For these commits, the cherry-pick will be restricted to the listed files only.
@@ -71,3 +72,4 @@ read -r -d '' SPACKPACKAGES_CHERRYPICKS_FILES <<- \
 ## 6fff3bd98c2157600cb716a3d7116f0a235446f1: acts: cleanup deps for removed versions
 ## 0e793b360b1383044923a19146f7d977f3107a41: pandora*: Update PandoraPFA repository URLs
 ## 4c53d69e7e02fb346500b6269e43a26d1010d0f7: pandora*: add v5.*
+## ded706e8eb08bae4ac1cd4618c594bee4040a00e: acts: pass root variant to examples


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR ensures that also for Acts v46 we continue to build the ROOT bindings, which moved from plugins to the examples.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

This is a dependency of the material validation pipeline in the epic repo.

### What kind of change does this PR introduce?
- [x] Bug fix (issue: https://github.com/eic/epic/actions/runs/32656533809/job/97236921179?pr=1159)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
